### PR TITLE
feat: 회원가입 API 구현

### DIFF
--- a/src/main/java/doritos/doriroom/global/security/SecurityConfig.java
+++ b/src/main/java/doritos/doriroom/global/security/SecurityConfig.java
@@ -8,6 +8,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -29,4 +31,8 @@ public class SecurityConfig {
         return http.build();
     }
 
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 }

--- a/src/main/java/doritos/doriroom/user/controller/UserController.java
+++ b/src/main/java/doritos/doriroom/user/controller/UserController.java
@@ -1,4 +1,27 @@
 package doritos.doriroom.user.controller;
 
+
+import doritos.doriroom.global.dto.ApiResponse;
+import doritos.doriroom.user.dto.SignupRequestDto;
+import doritos.doriroom.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
 public class UserController {
+    private final UserService userService;
+
+    @PostMapping("/signup")
+    @Operation(summary = "회원가입")
+    public ApiResponse<Void> signup(@RequestBody @Valid SignupRequestDto request){
+        userService.signup(request);
+        return ApiResponse.ok();
+    }
 }

--- a/src/main/java/doritos/doriroom/user/controller/UserController.java
+++ b/src/main/java/doritos/doriroom/user/controller/UserController.java
@@ -1,0 +1,4 @@
+package doritos.doriroom.user.controller;
+
+public class UserController {
+}

--- a/src/main/java/doritos/doriroom/user/domain/RoomVisibility.java
+++ b/src/main/java/doritos/doriroom/user/domain/RoomVisibility.java
@@ -1,0 +1,5 @@
+package doritos.doriroom.user.domain;
+
+public enum RoomVisibility {
+    PUBLIC, PRIVATE, FOLLOWERS
+}

--- a/src/main/java/doritos/doriroom/user/domain/User.java
+++ b/src/main/java/doritos/doriroom/user/domain/User.java
@@ -1,0 +1,40 @@
+package doritos.doriroom.user.domain;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "users")
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor
+@Builder
+public class User {
+    @Id
+    private UUID userId;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false, unique = true)
+    private String nickname;
+
+    private String profileImageUrl;
+
+    @Column(nullable = false)
+    private Long credit = 0L;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RoomVisibility roomVisibility = RoomVisibility.PUBLIC;
+
+    @Column(nullable = false)
+    private int likeCount = 0;
+
+    @Column(nullable = false)
+    private int viewCount = 0;
+
+    // TODO: 연관관계 매핑
+}

--- a/src/main/java/doritos/doriroom/user/dto/SignupRequestDto.java
+++ b/src/main/java/doritos/doriroom/user/dto/SignupRequestDto.java
@@ -1,10 +1,15 @@
 package doritos.doriroom.user.dto;
+import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
 @Getter
 public class SignupRequestDto {
+
+    @NotBlank
     private String username;
+    @NotBlank
     private String password;
+    @NotBlank
     private String nickname;
     // private String profileImageUrl;
 }

--- a/src/main/java/doritos/doriroom/user/dto/SignupRequestDto.java
+++ b/src/main/java/doritos/doriroom/user/dto/SignupRequestDto.java
@@ -1,0 +1,8 @@
+package doritos.doriroom.user.dto;
+
+public class SignupRequestDto {
+    private String username;
+    private String password;
+    private String nickname;
+    // private String profileImageUrl;
+}

--- a/src/main/java/doritos/doriroom/user/dto/SignupRequestDto.java
+++ b/src/main/java/doritos/doriroom/user/dto/SignupRequestDto.java
@@ -1,5 +1,7 @@
 package doritos.doriroom.user.dto;
+import lombok.*;
 
+@Getter
 public class SignupRequestDto {
     private String username;
     private String password;

--- a/src/main/java/doritos/doriroom/user/exception/DuplicateException.java
+++ b/src/main/java/doritos/doriroom/user/exception/DuplicateException.java
@@ -1,0 +1,10 @@
+package doritos.doriroom.user.exception;
+
+import doritos.doriroom.global.exception.ApiException;
+import org.springframework.http.HttpStatus;
+
+public class DuplicateException extends ApiException {
+    public DuplicateException(String field) {
+        super(HttpStatus.CONFLICT, "이미 사용 중인 " + field + "입니다.");
+    }
+}

--- a/src/main/java/doritos/doriroom/user/repository/UserRepository.java
+++ b/src/main/java/doritos/doriroom/user/repository/UserRepository.java
@@ -1,0 +1,4 @@
+package doritos.doriroom.user.repository;
+
+public class UserRepository {
+}

--- a/src/main/java/doritos/doriroom/user/repository/UserRepository.java
+++ b/src/main/java/doritos/doriroom/user/repository/UserRepository.java
@@ -1,4 +1,16 @@
 package doritos.doriroom.user.repository;
 
-public class UserRepository {
+import doritos.doriroom.user.domain.User;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, UUID> {
+    // username, nickname 중복 검사
+    boolean existsByUsername(String username);
+    boolean existsByNickname(String nickname);
+
+    // 로그인 시 유저 조회
+    User findByUsername(String username);
 }

--- a/src/main/java/doritos/doriroom/user/service/UserService.java
+++ b/src/main/java/doritos/doriroom/user/service/UserService.java
@@ -1,4 +1,40 @@
 package doritos.doriroom.user.service;
 
+import doritos.doriroom.user.domain.User;
+import doritos.doriroom.user.dto.SignupRequestDto;
+import doritos.doriroom.user.exception.DuplicateException;
+import doritos.doriroom.user.repository.UserRepository;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Builder
 public class UserService {
+    private final UserRepository userRepository;
+    private final PasswordEncoder encoder;
+
+    public void signup(SignupRequestDto request) {
+        // 중복 아이디, 닉네임 예외 처리
+        if (userRepository.existsByUsername(request.getUsername())) {
+            throw new DuplicateException("아이디");
+        }
+        if (userRepository.existsByNickname(request.getNickname())) {
+            throw new DuplicateException("닉네임");
+        }
+
+        User user = User.builder()
+                .userId(UUID.randomUUID())
+                .username(request.getUsername())
+                .password(encoder.encode(request.getPassword()))
+                .nickname(request.getNickname())
+                .build();
+
+        userRepository.save(user);
+    }
+
 }

--- a/src/main/java/doritos/doriroom/user/service/UserService.java
+++ b/src/main/java/doritos/doriroom/user/service/UserService.java
@@ -1,0 +1,4 @@
+package doritos.doriroom.user.service;
+
+public class UserService {
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
#4 

## 📝작업 내용

User 기본 엔티티 설계
회원가입 요청을 처리하는 컨트롤러, 서비스, DTO, 레포지토리 작성
username, nickname 중복 시 DuplicateException 처리
PasswordEncoder 사용하여 비밀번호 암호화 저장 (SecurityConfig에 Bean 정의)
Swagger 문서화


## 💬리뷰 요구사항

> SecurityConfig에 변경 사항이 있으니 참고해주세요!