### PR TITLE
Feat: 실시간 검색어 조회 기능 구현

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -67,4 +67,5 @@ jobs:
             docker run -d -p 8080:8080 --name backend \
               -v $(pwd)/app.yml:/app/config/application.yml \
               -e SPRING_CONFIG_LOCATION=file:/app/config/ \
+              --network host \
               ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE_NAME }}

--- a/src/main/java/doritos/doriroom/event/controller/EventController.java
+++ b/src/main/java/doritos/doriroom/event/controller/EventController.java
@@ -6,6 +6,7 @@ import doritos.doriroom.event.dto.response.EventDetailResponseDto;
 import doritos.doriroom.event.dto.response.EventResponseDto;
 import doritos.doriroom.event.service.EventService;
 import doritos.doriroom.global.dto.ApiResponse;
+import doritos.doriroom.search.service.SearchService;
 import io.swagger.v3.oas.annotations.*;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/event")
 public class EventController {
     private final EventService eventService;
+    private final SearchService searchService;
 
     @Operation(summary = "따끈따끈 신규 축제 조회")
     @GetMapping("/upcoming")
@@ -52,6 +54,11 @@ public class EventController {
         @ParameterObject EventItemFilterRequestDto request,
         @ParameterObject Pageable pageable
     ){
+        //인기검색어 카운트+1
+        if(request.keyword() != null && !request.keyword().trim().isEmpty()){
+            searchService.recordSearch(request.keyword());
+        }
+
         return ApiResponse.ok(eventService.getFilteredEvents(request, pageable));
     }
 

--- a/src/main/java/doritos/doriroom/global/config/RedisConfig.java
+++ b/src/main/java/doritos/doriroom/global/config/RedisConfig.java
@@ -1,0 +1,27 @@
+package doritos.doriroom.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+        
+        template.afterPropertiesSet();
+        return template;
+    }
+} 

--- a/src/main/java/doritos/doriroom/search/controller/SearchController.java
+++ b/src/main/java/doritos/doriroom/search/controller/SearchController.java
@@ -1,0 +1,28 @@
+package doritos.doriroom.search.controller;
+
+import doritos.doriroom.global.dto.ApiResponse;
+import doritos.doriroom.search.dto.SearchRankDto;
+import doritos.doriroom.search.service.SearchService;
+import io.swagger.v3.oas.annotations.*;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name="검색 관련", description = "오늘의 실시간 검색어 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/search")
+public class SearchController {
+    
+    private final SearchService searchService;
+    
+    @Operation(summary = "오늘의 인기 검색어 조회", description = "오늘의 인기 검색어를 순위와 함께 조회")
+    @GetMapping("/popular")
+    public ApiResponse<List<SearchRankDto>> getPopularKeywords(
+    ) {
+        List<SearchRankDto> keywords = searchService.getPopularKeywordsWithRank();
+        return ApiResponse.ok(keywords);
+    }
+} 

--- a/src/main/java/doritos/doriroom/search/dto/RankChange.java
+++ b/src/main/java/doritos/doriroom/search/dto/RankChange.java
@@ -1,0 +1,5 @@
+package doritos.doriroom.search.dto;
+
+public enum RankChange {
+    UP, DOWN, SAME
+}

--- a/src/main/java/doritos/doriroom/search/dto/SearchRankDto.java
+++ b/src/main/java/doritos/doriroom/search/dto/SearchRankDto.java
@@ -1,0 +1,15 @@
+package doritos.doriroom.search.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SearchRankDto {
+    private String keyword;
+    private Long count;
+    private Integer rank;
+    private RankChange change;
+}

--- a/src/main/java/doritos/doriroom/search/repository/SearchRepository.java
+++ b/src/main/java/doritos/doriroom/search/repository/SearchRepository.java
@@ -46,15 +46,22 @@ public class SearchRepository {
     }
 
     public List<SearchRankDto> getTopKeywordsWithRankChange() {
+        String today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
         String currentHour = getCurrentHourKey();
         String previousHour = getPreviousHourKey();
 
+        String todayKey = SEARCH_KEYWORDS_TODAY + today;
         String currentHourKey = SEARCH_KEYWORDS_HOURLY + currentHour;
         String previousHourKey = SEARCH_KEYWORDS_HOURLY + previousHour;
 
         // 현재 시간대 상위 10개
         Set<ZSetOperations.TypedTuple<Object>> currentTop =
             redisTemplate.opsForZSet().reverseRangeWithScores(currentHourKey, 0, 9);
+
+        // 현재 시간대 데이터가 없으면 오늘 전체 데이터 사용
+        if (currentTop.isEmpty()) {
+            currentTop = redisTemplate.opsForZSet().reverseRangeWithScores(todayKey, 0, 9);
+        }
 
         // 이전 시간대 상위 10개
         Set<ZSetOperations.TypedTuple<Object>> previousTop =

--- a/src/main/java/doritos/doriroom/search/repository/SearchRepository.java
+++ b/src/main/java/doritos/doriroom/search/repository/SearchRepository.java
@@ -59,7 +59,7 @@ public class SearchRepository {
             redisTemplate.opsForZSet().reverseRangeWithScores(currentHourKey, 0, 9);
 
         // 현재 시간대 데이터가 없으면 오늘 전체 데이터 사용
-        if (currentTop.isEmpty()) {
+        if (currentTop.isEmpty() || currentTop.size() < 10) {
             currentTop = redisTemplate.opsForZSet().reverseRangeWithScores(todayKey, 0, 9);
         }
 
@@ -70,9 +70,7 @@ public class SearchRepository {
         // 순위 변화 계산
         Map<String, Integer> previousRanks = new HashMap<>();
         AtomicInteger rank = new AtomicInteger(1);
-        previousTop.forEach(tuple -> {
-            previousRanks.put((String) tuple.getValue(), rank.getAndIncrement());
-        });
+        previousTop.forEach(tuple -> previousRanks.put((String) tuple.getValue(), rank.getAndIncrement()));
 
         // 결과 생성
         AtomicInteger currentRank = new AtomicInteger(1);

--- a/src/main/java/doritos/doriroom/search/repository/SearchRepository.java
+++ b/src/main/java/doritos/doriroom/search/repository/SearchRepository.java
@@ -1,0 +1,107 @@
+package doritos.doriroom.search.repository;
+
+import doritos.doriroom.search.dto.RankChange;
+import doritos.doriroom.search.dto.SearchRankDto;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Set;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class SearchRepository {
+    
+    private final RedisTemplate<String, Object> redisTemplate;
+    private static final String SEARCH_KEYWORDS_TODAY = "search:keywords:today:";
+    private static final String SEARCH_KEYWORDS_HOURLY = "search:keywords:hourly:";
+
+    //검색어 카운트 증가
+    public void incrementSearchCount(String keyword) {
+        String today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        String currentHour = getCurrentHourKey();
+
+        String todayKey = SEARCH_KEYWORDS_TODAY + today;
+        String hourlyKey = SEARCH_KEYWORDS_HOURLY + currentHour;
+
+        // 오늘 전체 카운트 증가
+        redisTemplate.opsForZSet().incrementScore(todayKey, keyword, 1);
+
+        // 현재 시간대 카운트 증가
+        redisTemplate.opsForZSet().incrementScore(hourlyKey, keyword, 1);
+
+        // TTL 설정
+        redisTemplate.expire(todayKey, java.time.Duration.ofDays(7));
+        redisTemplate.expire(hourlyKey, java.time.Duration.ofHours(24));
+    }
+
+    public List<SearchRankDto> getTopKeywordsWithRankChange() {
+        String currentHour = getCurrentHourKey();
+        String previousHour = getPreviousHourKey();
+
+        String currentHourKey = SEARCH_KEYWORDS_HOURLY + currentHour;
+        String previousHourKey = SEARCH_KEYWORDS_HOURLY + previousHour;
+
+        // 현재 시간대 상위 10개
+        Set<ZSetOperations.TypedTuple<Object>> currentTop =
+            redisTemplate.opsForZSet().reverseRangeWithScores(currentHourKey, 0, 9);
+
+        // 이전 시간대 상위 10개
+        Set<ZSetOperations.TypedTuple<Object>> previousTop =
+            redisTemplate.opsForZSet().reverseRangeWithScores(previousHourKey, 0, 9);
+
+        // 순위 변화 계산
+        Map<String, Integer> previousRanks = new HashMap<>();
+        AtomicInteger rank = new AtomicInteger(1);
+        previousTop.forEach(tuple -> {
+            previousRanks.put((String) tuple.getValue(), rank.getAndIncrement());
+        });
+
+        // 결과 생성
+        AtomicInteger currentRank = new AtomicInteger(1);
+        return currentTop.stream()
+            .map(tuple -> {
+                String keyword = (String) tuple.getValue();
+                Long currentCount = tuple.getScore().longValue();
+                Integer prevRank = previousRanks.get(keyword);
+                Integer currRank = currentRank.getAndIncrement();
+
+                RankChange change = calculateRankChange(currRank, prevRank);
+
+                return new SearchRankDto(keyword, currentCount, currRank, change);
+            })
+            .toList();
+    }
+
+    private String getCurrentHourKey() {
+        return LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd:HH"));
+    }
+
+    private String getPreviousHourKey() {
+        return LocalDateTime.now().minusHours(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd:HH"));
+    }
+
+    private RankChange calculateRankChange(Integer currentRank, Integer previousRank) {
+        if (previousRank == null) {
+            return RankChange.UP;
+        }
+
+        if (currentRank < previousRank) {
+            return RankChange.UP;
+        } else if (currentRank > previousRank) {
+            return RankChange.DOWN;
+        } else {
+            return RankChange.SAME;
+        }
+    }
+} 

--- a/src/main/java/doritos/doriroom/search/service/SearchService.java
+++ b/src/main/java/doritos/doriroom/search/service/SearchService.java
@@ -1,0 +1,37 @@
+package doritos.doriroom.search.service;
+
+import doritos.doriroom.search.dto.SearchRankDto;
+import doritos.doriroom.search.repository.SearchRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SearchService {
+    
+    private final SearchRepository searchRepository;
+
+    public void recordSearch(String keyword) {
+        if (keyword == null || keyword.trim().isEmpty()) {
+            log.warn("빈 검색어는 기록하지 않습니다.");
+            return;
+        }
+        
+        String normalizedKeyword = normalizeKeyword(keyword);
+        searchRepository.incrementSearchCount(normalizedKeyword);
+    }
+    
+    public List<SearchRankDto> getPopularKeywordsWithRank() {
+        return searchRepository.getTopKeywordsWithRankChange();
+    }
+
+    private String normalizeKeyword(String keyword) {
+        return keyword.trim()
+            .toLowerCase()
+            .replaceAll("\\s+", " ");  // 연속 공백을 하나로
+    }
+} 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #3 

## 📝작업 내용
실시간 검색어 조회 기능을 구현했습니다.
순위 상승/하락 기준은 시간대별로 비교해서 이전 시간대보다 검색량이 작으면 DOWN, 높으면 UP, 같으면 SAME으로 구현했습니다.
만약 현재 시간대 검색 기록이 없거나 10개 미만이면 오늘 전체 데이터를 사용했습니다.
