### PR TITLE
Bug/39 jwt filter

### DIFF
--- a/src/main/java/doritos/doriroom/global/exception/ApiExceptionHandler.java
+++ b/src/main/java/doritos/doriroom/global/exception/ApiExceptionHandler.java
@@ -70,7 +70,7 @@ public class ApiExceptionHandler {
     @ExceptionHandler(ApiException.class)
     public ApiResponse<?> apiException(ApiException e) {
 
-        return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+        return ApiResponse.error(e.getHttpStatus(), e.getMessage());
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/doritos/doriroom/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/doritos/doriroom/global/jwt/JwtAuthenticationFilter.java
@@ -1,11 +1,16 @@
 package doritos.doriroom.global.jwt;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import doritos.doriroom.global.dto.ApiResponse;
+import doritos.doriroom.global.exception.ApiException;
 import doritos.doriroom.user.domain.User;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
@@ -13,12 +18,12 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.rmi.server.ServerCloneException;
 
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtUtil jwtUtil;
+    private final ObjectMapper objectMapper;
 
    @Override
     public void doFilterInternal(
@@ -28,19 +33,28 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             throws ServletException, IOException {
 
         String token = extractToken(request);
-        if (token != null && jwtUtil.validateToken(token)) {
-            User user = jwtUtil.getUserFromToken(token);
 
-            if (user != null) {
+        try {
+            if (token != null) {
+                jwtUtil.validateToken(token); // 토큰 유효성 검사
+
+                User user = jwtUtil.getUserFromToken(token);
+
+                // SecurityContext 설정
                 UsernamePasswordAuthenticationToken authentication =
                         new UsernamePasswordAuthenticationToken(user, null, null);
 
-                authentication.setDetails(
-                        new WebAuthenticationDetailsSource().buildDetails(request)
-                );
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
+        } catch (TokenExpiredException e) {
+            errorResponse(response, e);
+            return;
+        } catch (JwtException e) {
+            errorResponse(response, new ApiException(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰 입니다."));
+            return;
         }
+
         filterChain.doFilter(request, response);
     }
 
@@ -51,6 +65,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return header.substring(7);
         }
         return null;
+    }
+
+    private void errorResponse(HttpServletResponse response, ApiException e) throws IOException {
+        response.setStatus(e.getHttpStatus().value());
+        response.setContentType("application/json");
+        response.getWriter().write(objectMapper.writeValueAsString(ApiResponse.error(e.getHttpStatus(), e.getMessage())));
     }
 
 }

--- a/src/main/java/doritos/doriroom/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/doritos/doriroom/global/jwt/JwtAuthenticationFilter.java
@@ -9,11 +9,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.rmi.server.ServerCloneException;
 
+@Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtUtil jwtUtil;

--- a/src/main/java/doritos/doriroom/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/doritos/doriroom/global/jwt/JwtAuthenticationFilter.java
@@ -73,4 +73,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         response.getWriter().write(objectMapper.writeValueAsString(ApiResponse.error(e.getHttpStatus(), e.getMessage())));
     }
 
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String path = request.getRequestURI();
+        return path.equals("/api/auth/reissue");
+    }
+
 }

--- a/src/main/java/doritos/doriroom/global/jwt/JwtUtil.java
+++ b/src/main/java/doritos/doriroom/global/jwt/JwtUtil.java
@@ -62,14 +62,13 @@ public class JwtUtil {
         return token;
     }
 
-    public boolean validateToken(String token) {
-        if (token == null || token.isBlank())  return false;
+    public void validateToken(String token) {
+        if (token == null || token.isBlank())  throw new JwtException("토큰이 비어 있습니다.");
 
         try{
             Jwts.parserBuilder().setSigningKey(getSignKey()).build().parseClaimsJws(token);
-            return true;
-        } catch (JwtException e) {
-            return false;
+        } catch (ExpiredJwtException e) {   throw new TokenExpiredException();
+        } catch (JwtException e) { throw new JwtException("유효하지 않은 토큰 입니다.", e);
         }
     }
 

--- a/src/main/java/doritos/doriroom/global/jwt/JwtUtil.java
+++ b/src/main/java/doritos/doriroom/global/jwt/JwtUtil.java
@@ -78,15 +78,11 @@ public class JwtUtil {
     }
 
     public User getUserFromToken(String token) {
-        try{
-            String username = getUsernameFromToken(token);
-            if(username == null)    return null;
+        String username = getUsernameFromToken(token);
+        if(username == null| username.isBlank())
+            throw new JwtException("토큰에서 username을 추출할 수 없습니다.");
 
             return userRepository.findByUsername(username)
                     .orElseThrow(UsernameNotFoundException::new);
-
-        } catch (Exception e){
-            return null;
-        }
     }
 }

--- a/src/main/java/doritos/doriroom/global/jwt/JwtUtil.java
+++ b/src/main/java/doritos/doriroom/global/jwt/JwtUtil.java
@@ -7,6 +7,7 @@ import doritos.doriroom.user.repository.RefreshTokenRedisRepository;
 import doritos.doriroom.user.domain.User;
 import doritos.doriroom.user.repository.UserRepository;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.ServletException;
 import lombok.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;

--- a/src/main/java/doritos/doriroom/global/jwt/TokenExpiredException.java
+++ b/src/main/java/doritos/doriroom/global/jwt/TokenExpiredException.java
@@ -5,6 +5,6 @@ import org.springframework.http.HttpStatus;
 
 public class TokenExpiredException extends ApiException {
     public TokenExpiredException() {
-        super(HttpStatus.BAD_REQUEST, "만료된 토큰 입니다.");
+        super(HttpStatus.UNAUTHORIZED, "만료된 토큰 입니다.");
     }
 }

--- a/src/main/java/doritos/doriroom/global/jwt/TokenExpiredException.java
+++ b/src/main/java/doritos/doriroom/global/jwt/TokenExpiredException.java
@@ -1,0 +1,10 @@
+package doritos.doriroom.global.jwt;
+
+import doritos.doriroom.global.exception.ApiException;
+import org.springframework.http.HttpStatus;
+
+public class TokenExpiredException extends ApiException {
+    public TokenExpiredException() {
+        super(HttpStatus.BAD_REQUEST, "만료된 토큰 입니다.");
+    }
+}

--- a/src/main/java/doritos/doriroom/global/security/SecurityConfig.java
+++ b/src/main/java/doritos/doriroom/global/security/SecurityConfig.java
@@ -27,7 +27,8 @@ public class SecurityConfig {
             .httpBasic(AbstractHttpConfigurer::disable)
             .authorizeHttpRequests(authorize -> authorize
                 .requestMatchers(SWAGGER_ENDPOINTS).permitAll()
-                .requestMatchers("/api/**").permitAll()
+                .requestMatchers("/api/users/**").permitAll()
+                .requestMatchers("/api/**").authenticated()
             );
         return http.build();
     }

--- a/src/main/java/doritos/doriroom/global/security/SecurityConfig.java
+++ b/src/main/java/doritos/doriroom/global/security/SecurityConfig.java
@@ -2,6 +2,7 @@ package doritos.doriroom.global.security;
 
 import static org.springframework.security.config.Customizer.withDefaults;
 
+import doritos.doriroom.global.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,11 +12,13 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {
     private static final String[] SWAGGER_ENDPOINTS = { "/swagger", "/swagger-ui/**", "/api-docs/**", "/v3/api-docs/**" };
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -29,7 +32,8 @@ public class SecurityConfig {
                 .requestMatchers(SWAGGER_ENDPOINTS).permitAll()
                 .requestMatchers("/api/users/**").permitAll()
                 .requestMatchers("/api/**").authenticated()
-            );
+            ).addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
         return http.build();
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#39 

## 📝작업 내용


- 회원가입, 로그인, 토큰 재발급 API는 permitAll()로 허용
- 그 외 요청은 authenticated()로 보호
- JWT 인증 필터 추가 및 SecurityFilterChain에 등록
- 토큰 유효성 검사 및 만료 예외 처리 로직 구현



## 💬리뷰 요구사항(선택)

ApiResponse에서 응답 상태 코드를 반환 받도록 수정했는데 확인 부탁드립니다!