### PR TITLE
Feature/66 s3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,11 +59,14 @@ dependencies {
 	// MacOS
 	runtimeOnly "io.netty:netty-resolver-dns-native-macos:4.1.107.Final:osx-aarch_64"
 
-	//QueryDSL
+	// QueryDSL
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // aws
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 

--- a/src/main/java/doritos/doriroom/global/config/S3Config.java
+++ b/src/main/java/doritos/doriroom/global/config/S3Config.java
@@ -1,0 +1,33 @@
+package doritos.doriroom.global.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return (AmazonS3Client) AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+}

--- a/src/main/java/doritos/doriroom/s3/S3Uploader.java
+++ b/src/main/java/doritos/doriroom/s3/S3Uploader.java
@@ -2,7 +2,6 @@ package doritos.doriroom.s3;
 
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3URI;
-import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import doritos.doriroom.s3.exception.ImageUploadException;
@@ -11,11 +10,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -26,7 +23,6 @@ public class S3Uploader {
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
-
 
     private static final List<String> ALLOWED_EXTENSIONS = Arrays.asList("jpg", "jpeg", "png", "gif", "bmp", "webp"); // 파일 확장자 지정
     private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 파일 크기 지정 (10MB)
@@ -74,8 +70,6 @@ public class S3Uploader {
     }
 
 
-
-
     /* 내부 메서드 */
 
     // s3에 파일 업로드
@@ -119,11 +113,4 @@ public class S3Uploader {
         return  fileName.substring(fileName.lastIndexOf(".") + 1);
     }
 
-//    // url에서 key 추출
-//    private String getKeyFromUrl(String url) {
-//        if (!url.startsWith(BASE_URL)) {
-//            throw new ImageUploadException("유효하지 않은 S3 URL입니다. (" + url +")");
-//        }
-//        return url.substring(BASE_URL.length());
-//    }
 }

--- a/src/main/java/doritos/doriroom/s3/S3Uploader.java
+++ b/src/main/java/doritos/doriroom/s3/S3Uploader.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import doritos.doriroom.s3.exception.ImageUploadException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
@@ -17,6 +18,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class S3Uploader {
@@ -58,7 +60,11 @@ public class S3Uploader {
         try {
             AmazonS3URI s3Uri = new AmazonS3URI(fileUrl); // URI 파싱
             s3Client.deleteObject(s3Uri.getBucket(), s3Uri.getKey()); // 이미지 삭제
+            log.info("S3 파일 삭제 성공: {}", fileUrl);
+        } catch (IllegalArgumentException e) {
+            log.warn("유효하지 않은 S3 URL 형식입니다: {}", fileUrl);
         } catch (Exception e) {
+            log.error("S3 파일 삭제 중 오류가 발생했습니다.", e);
             throw new ImageUploadException("이미지 삭제 중 오류가 발생했습니다: " + e.getMessage());
         }
     }
@@ -83,7 +89,9 @@ public class S3Uploader {
             s3Client.putObject(
                     new PutObjectRequest(bucket, key, multipartFile.getInputStream(), null)
                             .withCannedAcl(CannedAccessControlList.PublicRead)  );
+            log.info("S3 이미지 업로드 성공: {}", key);
         } catch (IOException e) {
+            log.error("S3 파일 업로드 중 IO 에러 발생", e);
             throw new ImageUploadException("파일 업로드에 실패했습니다.");
         }
         return s3Client.getUrl(bucket, key).toString(); // 업로드된 파일의 url

--- a/src/main/java/doritos/doriroom/s3/S3Uploader.java
+++ b/src/main/java/doritos/doriroom/s3/S3Uploader.java
@@ -1,13 +1,23 @@
-package doritos.doriroom.global.s3;
+package doritos.doriroom.s3;
 
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3URI;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import doritos.doriroom.s3.exception.ImageUploadException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -17,7 +27,103 @@ public class S3Uploader {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    private Optional<File> convert(MultipartFile file) {
 
+    private static final List<String> ALLOWED_EXTENSIONS = Arrays.asList("jpg", "jpeg", "png", "gif", "bmp", "webp"); // 파일 확장자 지정
+    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 파일 크기 지정 (10MB)
+    private static final int MAX_FILE_COUNT = 5; // 한번에 업로드 가능한 파일 개수 지정
+
+
+    // 단일 이미지 업로드
+    public String uploadFile(MultipartFile multipartFile, String dirName) {
+        if (multipartFile == null || multipartFile.isEmpty())   return null; // 파일이 없는 경우 그냥 넘김
+
+        validateFile(multipartFile);
+        return uploadToS3(multipartFile, dirName);
     }
+
+    // 다중 이미지 업로드
+    public List<String> uploadFiles(List<MultipartFile> multipartFiles, String dirName) {
+        if (multipartFiles == null || multipartFiles.isEmpty())     return List.of();
+        if (multipartFiles.size() > MAX_FILE_COUNT) {
+            throw new ImageUploadException("한 번에 최대 " + MAX_FILE_COUNT+"개의 파일만 업로드할 수 있습니다.");
+        }
+        return multipartFiles.stream()
+                .filter(file -> file != null && !file.isEmpty())
+                .peek(this::validateFile)
+                .map(file -> uploadToS3(file, dirName))
+                .collect(Collectors.toList());
+    }
+
+    // 단일 이미지 삭제
+    public void deleteFile(String fileUrl) {
+        if (fileUrl == null || fileUrl.isBlank())   return;
+
+        try {
+            AmazonS3URI s3Uri = new AmazonS3URI(fileUrl); // URI 파싱
+            s3Client.deleteObject(s3Uri.getBucket(), s3Uri.getKey()); // 이미지 삭제
+        } catch (Exception e) {
+            throw new ImageUploadException("이미지 삭제 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+
+    // 다중 이미지 삭제
+    public void deleteFiles(List<String> fileUrls) {
+        if (fileUrls == null || fileUrls.isEmpty())     return;
+
+        fileUrls.forEach(this::deleteFile);
+    }
+
+
+
+
+    /* 내부 메서드 */
+
+    // s3에 파일 업로드
+    private String uploadToS3(MultipartFile multipartFile, String dirName) {
+        String fileName = generateFileName(multipartFile.getOriginalFilename());
+        String key = dirName + "/" + fileName;
+
+        // s3 업로드
+        try  {
+            s3Client.putObject(
+                    new PutObjectRequest(bucket, key, multipartFile.getInputStream(), null)
+                            .withCannedAcl(CannedAccessControlList.PublicRead)  );
+        } catch (IOException e) {
+            throw new ImageUploadException("파일 업로드에 실패했습니다.");
+        }
+        return s3Client.getUrl(bucket, key).toString(); // 업로드된 파일의 url
+    }
+
+    // 파일 검증
+    private void validateFile(MultipartFile file) {
+        if (file.getSize() > MAX_FILE_SIZE ) {
+            throw new ImageUploadException("파일 크기가 최대 용량(10MB)을 초과했습니다.");
+        }
+        String extension = getFileExtension(file.getOriginalFilename()).toLowerCase();
+        if (! ALLOWED_EXTENSIONS.contains(extension)){
+            throw new ImageUploadException("지원하지 않는 파일 형식입니다. (지원하는 형식: "+ ALLOWED_EXTENSIONS +")");
+        }
+    }
+
+    // 고유 파일명 랜덤 생성
+    private String generateFileName(String fileName) {
+        String extension = getFileExtension(fileName); // 확장자 추출
+        return UUID.randomUUID().toString() + "." + extension;
+    }
+
+    // 파일 확장자 추출
+    private String getFileExtension(String fileName) {
+        if (fileName == null || fileName.isEmpty() || !fileName.contains(".")) {
+            throw new ImageUploadException("잘못된 파일명입니다.");
+        }
+        return  fileName.substring(fileName.lastIndexOf(".") + 1);
+    }
+
+//    // url에서 key 추출
+//    private String getKeyFromUrl(String url) {
+//        if (!url.startsWith(BASE_URL)) {
+//            throw new ImageUploadException("유효하지 않은 S3 URL입니다. (" + url +")");
+//        }
+//        return url.substring(BASE_URL.length());
+//    }
 }

--- a/src/main/java/doritos/doriroom/s3/S3Uploader.java
+++ b/src/main/java/doritos/doriroom/s3/S3Uploader.java
@@ -1,0 +1,23 @@
+package doritos.doriroom.global.s3;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class S3Uploader {
+    private final AmazonS3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private Optional<File> convert(MultipartFile file) {
+
+    }
+}

--- a/src/main/java/doritos/doriroom/s3/S3Uploader.java
+++ b/src/main/java/doritos/doriroom/s3/S3Uploader.java
@@ -15,6 +15,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -48,11 +49,32 @@ public class S3Uploader {
         if (multipartFiles.size() > MAX_FILE_COUNT) {
             throw new ImageUploadException("한 번에 최대 " + MAX_FILE_COUNT+"개의 파일만 업로드할 수 있습니다.");
         }
-        return multipartFiles.stream()
-                .filter(file -> file != null && !file.isEmpty())
-                .peek(this::validateFile)
-                .map(file -> uploadToS3(file, dirName))
-                .collect(Collectors.toList());
+
+        // 트랜잭션 수동 롤백 처리
+        List<String> uploadedFiles = new ArrayList<>();
+
+        try {
+            for (MultipartFile file : multipartFiles) {
+                if (file != null && !file.isEmpty()) {
+                    validateFile(file);
+                    uploadedFiles.add(uploadToS3(file, dirName)); // 업로드 된 파일의 url 추가
+                }
+            }
+            log.info("다중 파일 업로드 완료: {} 개 파일", uploadedFiles.size());
+            return uploadedFiles;
+        }  catch (Exception e) {
+            log.error("다중 파일 업로드 실패", e);
+
+            uploadedFiles.forEach(file -> { // 업로드된 일부 파일들을 삭제
+                try {
+                    deleteFile(file);
+                    log.info("롤백: 파일 삭제 완료 - {}", file);
+                } catch (Exception de){
+                    log.warn("롤백 중 파일 삭제 실패: {}", file, de);
+                }
+            });
+            throw e;
+        }
     }
 
     // 단일 이미지 삭제

--- a/src/main/java/doritos/doriroom/s3/S3Uploader.java
+++ b/src/main/java/doritos/doriroom/s3/S3Uploader.java
@@ -8,6 +8,7 @@ import doritos.doriroom.s3.exception.ImageUploadException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -110,7 +111,7 @@ public class S3Uploader {
         if (fileName == null || fileName.isEmpty() || !fileName.contains(".")) {
             throw new ImageUploadException("잘못된 파일명입니다.");
         }
-        return  fileName.substring(fileName.lastIndexOf(".") + 1);
+        return StringUtils.getFilenameExtension(fileName);
     }
 
 }

--- a/src/main/java/doritos/doriroom/s3/S3Uploader.java
+++ b/src/main/java/doritos/doriroom/s3/S3Uploader.java
@@ -3,6 +3,7 @@ package doritos.doriroom.s3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3URI;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import doritos.doriroom.s3.exception.ImageUploadException;
 import lombok.RequiredArgsConstructor;
@@ -85,10 +86,16 @@ public class S3Uploader {
         String fileName = generateFileName(multipartFile.getOriginalFilename());
         String key = dirName + "/" + fileName;
 
+        // 메타 데이터 추가
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(multipartFile.getContentType());
+        metadata.setContentLength(multipartFile.getSize());
+
+
         // s3 업로드
         try (InputStream inputStream = multipartFile.getInputStream()) {
             s3Client.putObject(
-                    new PutObjectRequest(bucket, key, inputStream, null)
+                    new PutObjectRequest(bucket, key, inputStream, metadata)
                             .withCannedAcl(CannedAccessControlList.PublicRead)  );
             log.info("S3 이미지 업로드 성공: {}", key);
         } catch (IOException e) {
@@ -106,6 +113,10 @@ public class S3Uploader {
         String extension = getFileExtension(file.getOriginalFilename()).toLowerCase();
         if (! ALLOWED_EXTENSIONS.contains(extension)){
             throw new ImageUploadException("지원하지 않는 파일 형식입니다. (지원하는 형식: "+ ALLOWED_EXTENSIONS +")");
+        }
+        String contentType = file.getContentType();
+        if (contentType == null || !contentType.startsWith("image/")) {
+            throw new ImageUploadException("이미지 파일만 업로드 가능합니다.");
         }
     }
 

--- a/src/main/java/doritos/doriroom/s3/S3Uploader.java
+++ b/src/main/java/doritos/doriroom/s3/S3Uploader.java
@@ -13,6 +13,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -85,9 +86,9 @@ public class S3Uploader {
         String key = dirName + "/" + fileName;
 
         // s3 업로드
-        try  {
+        try (InputStream inputStream = multipartFile.getInputStream()) {
             s3Client.putObject(
-                    new PutObjectRequest(bucket, key, multipartFile.getInputStream(), null)
+                    new PutObjectRequest(bucket, key, inputStream, null)
                             .withCannedAcl(CannedAccessControlList.PublicRead)  );
             log.info("S3 이미지 업로드 성공: {}", key);
         } catch (IOException e) {

--- a/src/main/java/doritos/doriroom/s3/exception/ImageUploadException.java
+++ b/src/main/java/doritos/doriroom/s3/exception/ImageUploadException.java
@@ -1,0 +1,10 @@
+package doritos.doriroom.s3.exception;
+
+import doritos.doriroom.global.exception.ApiException;
+import org.springframework.http.HttpStatus;
+
+public class ImageUploadException extends ApiException {
+    public ImageUploadException(String message) {
+        super(HttpStatus.BAD_REQUEST, message);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#66 

## 📝작업 내용

aws s3 버킷을 연동하여 이미지 업로드 및 삭제 메서드를 정의한 공통 모듈(S3Uploader)을 구현했습니다.

## 주요 기능
- 단일/다중 파일 업로드 기능
- 단일/다중 파일 삭제 기능
- 파일 유효성 검사 (확장자, 크기, 개수)
- 다중 업로드 실패 시 올라간 일부 파일을 자동 삭제하도록 구현

## 사용 방법

필요한 컨트롤러나 서비스에 의존성 주입하여 사용합니다.
(예시) `String imageUrl = s3Uploader.uploadFile(file, dirName);`
```
String imageUrl = s3Uploader.uploadFile(file, "profiles"); // 단일 파일 업로드 (디렉토리명: "profiles")
List<String> imageUrls = s3Uploader.uploadFiles(files, "reviews"); // 다중 파일 업로드 (디렉토리명: "reviews")

s3Uploader.deleteFile(imageUrl); // 단일 파일 삭제
s3Uploader.deleteFiles(imageUrls); // 다중 파일 삭제
```

- 현재 임의로 정해진 파일 제한사항입니다.
    - 지원 형식: jpg, jpeg, png, gif, bmp, webp
    - 최대 크기: 10MB per 파일
    - 최대 개수: 5개 (다중 업로드 시)
    - 파일명: 자동으로 UUID로 변경됨


## 💬리뷰 요구사항(선택)

파일 제안사항을 정하면 좋을 것 같습니다!