### PR TITLE
Feature/28 mypage

### DIFF
--- a/src/main/java/doritos/doriroom/auth/exception/InvalidPasswordException.java
+++ b/src/main/java/doritos/doriroom/auth/exception/InvalidPasswordException.java
@@ -7,4 +7,7 @@ public class InvalidPasswordException extends ApiException {
     public InvalidPasswordException() {
         super(HttpStatus.BAD_REQUEST, "잘못된 비밀번호 입니다.");
     }
+    public InvalidPasswordException(String message) {
+        super(HttpStatus.BAD_REQUEST, message);
+    }
 }

--- a/src/main/java/doritos/doriroom/auth/service/AuthService.java
+++ b/src/main/java/doritos/doriroom/auth/service/AuthService.java
@@ -9,7 +9,7 @@ import doritos.doriroom.auth.domain.RefreshToken;
 import doritos.doriroom.user.domain.User;
 import doritos.doriroom.user.exception.DuplicateException;
 import doritos.doriroom.auth.repository.RefreshTokenRedisRepository;
-import doritos.doriroom.user.exception.UsernameNotFoundException;
+import doritos.doriroom.user.exception.UserNotFoundException;
 import doritos.doriroom.user.repository.UserRepository;
 import io.jsonwebtoken.Claims;
 import jakarta.mail.MessagingException;
@@ -126,7 +126,7 @@ public class AuthService {
 
     public LoginResponseDto login(LoginRequestDto request) {
         User user = userRepository.findByUsername(request.username())
-                .orElseThrow(() -> new UsernameNotFoundException());
+                .orElseThrow(() -> new UserNotFoundException());
 
         if (!encoder.matches(request.password(), user.getPassword())) {
             throw new InvalidPasswordException();
@@ -147,7 +147,7 @@ public class AuthService {
         UUID userId = storedToken.getUserId();
         String username = jwtUtil.getUsernameFromToken(storedToken.getRefreshToken());
         User user = userRepository.findByUsername(username)
-                .orElseThrow(UsernameNotFoundException::new);
+                .orElseThrow(UserNotFoundException::new);
 
         refreshTokenRedisRepository.deleteById(userId);
 
@@ -165,7 +165,7 @@ public class AuthService {
             throw new InvalidTokenException("토큰에서 username을 추출할 수 없습니다.");
 
         User user = userRepository.findByUsername(username)
-                .orElseThrow(UsernameNotFoundException::new);
+                .orElseThrow(UserNotFoundException::new);
 
         refreshTokenRedisRepository.deleteById(user.getUserId()); // 추출한 User의 리프레시 토큰 삭제
 

--- a/src/main/java/doritos/doriroom/diary/service/DiaryService.java
+++ b/src/main/java/doritos/doriroom/diary/service/DiaryService.java
@@ -11,7 +11,7 @@ import doritos.doriroom.event.exception.EventNotFoundException;
 import doritos.doriroom.event.repository.EventRepository;
 import doritos.doriroom.user.domain.RoomVisibility;
 import doritos.doriroom.user.domain.User;
-import doritos.doriroom.user.exception.UsernameNotFoundException;
+import doritos.doriroom.user.exception.UserNotFoundException;
 import doritos.doriroom.user.repository.UserRepository;
 import java.time.LocalDate;
 import java.util.*;
@@ -33,7 +33,7 @@ public class DiaryService {
 
     @Transactional
     public DiaryResponseDto createDiary(UUID userId, DiaryCreateRequestDto request){
-        User user = userRepository.findById(userId).orElseThrow(UsernameNotFoundException::new);
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
         Event event = eventRepository.findById(request.eventId()).orElseThrow(EventNotFoundException::new);
 
         Diary diary = Diary.from(userId, request);
@@ -51,7 +51,7 @@ public class DiaryService {
     @Transactional
     public DiaryResponseDto updateDiary(UUID userId, UUID diaryId, DiaryUpdateRequestDto request) {
         Diary diary = diaryRepository.findById(diaryId).orElseThrow(DiaryNotFoundException::new);
-        User user = userRepository.findById(userId).orElseThrow(UsernameNotFoundException::new);
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
         Event event = eventRepository.findById(diary.getEventId()).orElseThrow(EventNotFoundException::new);
 
         if (!diary.getUserId().equals(userId)) {
@@ -100,7 +100,7 @@ public class DiaryService {
             .orElseThrow(DiaryNotFoundException::new);
 
         User user = userRepository.findById(diary.getUserId())
-            .orElseThrow(UsernameNotFoundException::new);
+            .orElseThrow(UserNotFoundException::new);
 
         Event event = eventRepository.findById(diary.getEventId())
             .orElseThrow(EventNotFoundException::new);
@@ -122,7 +122,7 @@ public class DiaryService {
 
     //다른 유저의 월별 일기 작성 여부 조회
     public DiaryWritingStatusResponseDto getOtherUserDiaryWritingStatus(UUID userId, int year, int month) {
-        userRepository.findById(userId).orElseThrow(UsernameNotFoundException::new);
+        userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
 
         // 해당 월의 시작일과 종료일 계산
         LocalDate startDate = LocalDate.of(year, month, 1);
@@ -169,7 +169,7 @@ public class DiaryService {
             return DailyDiaryListResponseDto.from(userId, date, List.of());
         }
 
-        User user = userRepository.findById(userId).orElseThrow(UsernameNotFoundException::new);
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
 
         List<UUID> eventIds = diaries.stream()
             .map(Diary::getEventId)
@@ -219,7 +219,7 @@ public class DiaryService {
 
     //특정 유저의 일기 목록 조회
     public Page<DiaryResponseDto> getUserDiaries(UUID userId, Pageable pageable) {
-        User user = userRepository.findById(userId).orElseThrow(UsernameNotFoundException::new);
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
 
         Page<Diary> diaries = diaryRepository.findPublicByUserIdOrderByVisitedAtDesc(userId, pageable);
 

--- a/src/main/java/doritos/doriroom/event/controller/EventFavoriteController.java
+++ b/src/main/java/doritos/doriroom/event/controller/EventFavoriteController.java
@@ -6,7 +6,7 @@ import doritos.doriroom.event.dto.response.EventResponseDto;
 import doritos.doriroom.event.service.EventFavoriteService;
 import doritos.doriroom.global.dto.ApiResponse;
 import doritos.doriroom.user.domain.User;
-import doritos.doriroom.user.exception.UsernameNotFoundException;
+import doritos.doriroom.user.exception.UserNotFoundException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -35,7 +35,7 @@ public class EventFavoriteController {
         @RequestBody EventFavoriteRequestDto request
     ) {
         if (user == null) {
-            throw new UsernameNotFoundException();
+            throw new UserNotFoundException();
         }
 
         boolean isFavorite = eventFavoriteService.setFavoriteStatus(user, request.eventId(), request.isFavorite());
@@ -50,7 +50,7 @@ public class EventFavoriteController {
         @PathVariable("eventId") UUID eventId
     ) {
         if (user == null) {
-            throw new UsernameNotFoundException();
+            throw new UserNotFoundException();
         }
 
         boolean isLiked = eventFavoriteService.isLiked(user, eventId);
@@ -64,7 +64,7 @@ public class EventFavoriteController {
         @ParameterObject Pageable pageable
     ) {
         if (user == null) {
-            throw new UsernameNotFoundException();
+            throw new UserNotFoundException();
         }
 
         Page<EventResponseDto> favorites = eventFavoriteService.getUserFavoriteEvents(user, pageable);
@@ -78,7 +78,7 @@ public class EventFavoriteController {
         @RequestBody EventFavoriteDeleteRequestDto request
     ){
         if(user == null) {
-            throw new UsernameNotFoundException();
+            throw new UserNotFoundException();
         }
 
         int deletedCount = eventFavoriteService.deleteFavorites(user, request.eventIds());

--- a/src/main/java/doritos/doriroom/global/jwt/JwtUtil.java
+++ b/src/main/java/doritos/doriroom/global/jwt/JwtUtil.java
@@ -3,7 +3,7 @@ package doritos.doriroom.global.jwt;
 import doritos.doriroom.auth.domain.RefreshToken;
 import doritos.doriroom.auth.exception.InvalidTokenException;
 import doritos.doriroom.auth.exception.TokenExpiredException;
-import doritos.doriroom.user.exception.UsernameNotFoundException;
+import doritos.doriroom.user.exception.UserNotFoundException;
 import doritos.doriroom.auth.repository.RefreshTokenRedisRepository;
 import doritos.doriroom.user.domain.User;
 import doritos.doriroom.user.repository.UserRepository;
@@ -105,7 +105,7 @@ public class JwtUtil {
             throw new InvalidTokenException("토큰에서 username을 추출할 수 없습니다.");
 
             return userRepository.findByUsername(username)
-                    .orElseThrow(UsernameNotFoundException::new);
+                    .orElseThrow(UserNotFoundException::new);
     }
 
     public Claims parseClaims(String token) {

--- a/src/main/java/doritos/doriroom/guestbook/service/GuestbookService.java
+++ b/src/main/java/doritos/doriroom/guestbook/service/GuestbookService.java
@@ -8,7 +8,7 @@ import doritos.doriroom.guestbook.exception.GuestbookNotFoundException;
 import doritos.doriroom.guestbook.exception.SelfGuestbookNotAllowedException;
 import doritos.doriroom.guestbook.repository.GuestbookRepository;
 import doritos.doriroom.user.domain.User;
-import doritos.doriroom.user.exception.UsernameNotFoundException;
+import doritos.doriroom.user.exception.UserNotFoundException;
 import doritos.doriroom.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -29,7 +29,7 @@ public class GuestbookService {
     public GuestbookResponseDto createGuestbook(UUID writerId, GuestbookRequestDto request) {
         // 방 주인 존재 여부 확인
         userRepository.findById(request.roomOwnerId())
-                .orElseThrow(UsernameNotFoundException::new);
+                .orElseThrow(UserNotFoundException::new);
 
         // 자신의 방에 방명록을 작성하려는 경우 예외 처리
         if (writerId.equals(request.roomOwnerId())) {
@@ -43,14 +43,14 @@ public class GuestbookService {
 
     public Page<GuestbookResponseDto> getGuestbooksByRoomOwner(UUID roomOwnerId, Pageable pageable) {
         if (!userRepository.existsById(roomOwnerId)) {
-            throw new UsernameNotFoundException();
+            throw new UserNotFoundException();
         }
 
         Page<Guestbook> guestbooks = guestbookRepository.findByRoomOwnerIdOrderByCreatedAtDesc(roomOwnerId, pageable);
 
         return guestbooks.map(guestbook -> {
             userRepository.findById(guestbook.getWriterId())
-                    .orElseThrow(UsernameNotFoundException::new);
+                    .orElseThrow(UserNotFoundException::new);
             return GuestbookResponseDto.from(guestbook);
         });
     }

--- a/src/main/java/doritos/doriroom/user/controller/UserController.java
+++ b/src/main/java/doritos/doriroom/user/controller/UserController.java
@@ -2,14 +2,21 @@ package doritos.doriroom.user.controller;
 
 
 import doritos.doriroom.global.dto.ApiResponse;
+import doritos.doriroom.user.domain.User;
+import doritos.doriroom.user.dto.request.ChangePasswordRequestDto;
+import doritos.doriroom.user.dto.request.UpdateProfileRequestDto;
+import doritos.doriroom.user.dto.response.ProfileImageResponseDto;
+import doritos.doriroom.user.dto.response.UserMyPageInfoDetailResponseDto;
+import doritos.doriroom.user.dto.response.UserMyPageInfoResponseDto;
 import doritos.doriroom.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "User", description = "")
 @RestController
@@ -36,4 +43,45 @@ public class UserController {
             return ApiResponse.ok();
         }
 
+        @GetMapping("/me")
+        @Operation(summary = "내 정보 조회 - 마이페이지")
+        public ApiResponse<UserMyPageInfoResponseDto> getUserInfo(@AuthenticationPrincipal User user){
+            return ApiResponse.ok(userService.getUserInfo(user));
+        }
+
+        @GetMapping("/me/detail")
+        @Operation(summary = "내 정보 상세 조회 - 내 정보 수정 페이지")
+        public ApiResponse<UserMyPageInfoDetailResponseDto> getUserInfoDetail(@AuthenticationPrincipal User user){
+            return ApiResponse.ok(userService.getUserInfoDetail(user));
+        }
+
+        @PutMapping("/me/profile")
+        @Operation(summary = "프로필 정보 수정 (닉네임)")
+        public ApiResponse<Void> updateProfile(@AuthenticationPrincipal User user,
+                                               @Valid @RequestBody UpdateProfileRequestDto request) {
+            userService.updateProfile(user, request);
+            return ApiResponse.ok();
+        }
+
+        @PostMapping("/me/profile-image")
+        @Operation(summary = "프로필 이미지 업로드")
+        public ApiResponse<ProfileImageResponseDto> uploadProfileImage(@AuthenticationPrincipal User user,
+                                                                       @RequestParam("file") MultipartFile file) {
+            return ApiResponse.ok(userService.uploadProfileImage(user, file));
+        }
+
+        @DeleteMapping("/me/profile-image")
+        @Operation(summary = "프로필 이미지 삭제")
+        public ApiResponse<Void> deleteProfileImage(@AuthenticationPrincipal User user) {
+            userService.deleteProfileImage(user);
+            return ApiResponse.ok();
+        }
+
+        @PutMapping("/me/password")
+        @Operation(summary = "비밀번호 변경")
+        public ApiResponse<Void> changePassword(@AuthenticationPrincipal User user,
+                                                @Valid @RequestBody ChangePasswordRequestDto request) {
+            userService.changePassword(user, request);
+            return ApiResponse.ok();
+        }
 }

--- a/src/main/java/doritos/doriroom/user/controller/UserController.java
+++ b/src/main/java/doritos/doriroom/user/controller/UserController.java
@@ -64,7 +64,13 @@ public class UserController {
         }
 
         @PostMapping("/me/profile-image")
-        @Operation(summary = "프로필 이미지 업로드")
+        @Operation(summary = "프로필 이미지 업로드", description = """
+            로그인한 사용자의 프로필 이미지를 업로드(또는 변경)합니다. `multipart/form-data` 형식으로 요청해야 합니다.
+            
+            **[제약 조건]**
+            - 파일 형식: `jpg`, `jpeg`, `png`, `gif`, `bmp`, `webp`
+            - 파일 크기: 최대 10MB
+            """)
         public ApiResponse<ProfileImageResponseDto> uploadProfileImage(@AuthenticationPrincipal User user,
                                                                        @RequestParam("file") MultipartFile file) {
             return ApiResponse.ok(userService.uploadProfileImage(user, file));

--- a/src/main/java/doritos/doriroom/user/dto/request/ChangePasswordRequestDto.java
+++ b/src/main/java/doritos/doriroom/user/dto/request/ChangePasswordRequestDto.java
@@ -1,0 +1,27 @@
+package doritos.doriroom.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record ChangePasswordRequestDto(
+        @NotBlank(message = "현재 비밀번호는 필수입니다")
+        @Schema(description = "현재 비밀번호")
+        String currentPassword,
+
+        @NotBlank(message = "새 비밀번호는 필수입니다")
+        @Pattern(regexp = "^(?=.{6,20}$)((?=.*[a-zA-Z])(?=.*\\d)|(?=.*[a-zA-Z])(?=.*[!@#$%^&*])|(?=.*\\d)(?=.*[!@#$%^&*])).*$",
+                message = "비밀번호는 영문, 숫자, 특수문자 중 2가지 이상을 조합하여 6~20자로 설정해야 합니다.")
+        @Schema(description = "새 비밀번호(영문/숫자/특수문자 포함 8~20자)", example = "Passw0rd!2")
+        String newPassword,
+
+        @NotBlank(message = "비밀번호 확인은 필수입니다")
+        @Schema(description = "새 비밀번호 확인")
+        String confirmPassword
+) {
+    @AssertTrue(message = "새 비밀번호와 확인 비밀번호가 일치하지 않습니다")
+    public boolean isPasswordMatching() {
+        return newPassword != null && newPassword.equals(confirmPassword);
+    }
+}

--- a/src/main/java/doritos/doriroom/user/dto/request/UpdateProfileRequestDto.java
+++ b/src/main/java/doritos/doriroom/user/dto/request/UpdateProfileRequestDto.java
@@ -1,0 +1,14 @@
+package doritos.doriroom.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+
+public record UpdateProfileRequestDto(
+        @NotBlank(message = "닉네임은 필수입니다")
+        @Size(min = 1, max = 10, message = "닉네임은 한글, 영문, 숫자 조합으로 1~10자만 가능합니다.")
+        @Schema(description = "닉네임", example = "도리토스2")
+        String nickname
+) {
+}

--- a/src/main/java/doritos/doriroom/user/dto/response/ProfileImageResponseDto.java
+++ b/src/main/java/doritos/doriroom/user/dto/response/ProfileImageResponseDto.java
@@ -1,0 +1,16 @@
+package doritos.doriroom.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record ProfileImageResponseDto(
+        @Schema(description = "업로드된 프로필 이미지 URL")
+        String profileImageUrl
+) {
+    public static ProfileImageResponseDto from(String profileImageUrl) {
+        return ProfileImageResponseDto.builder()
+                .profileImageUrl(profileImageUrl)
+                .build();
+    }
+}

--- a/src/main/java/doritos/doriroom/user/dto/response/UserMyPageInfoDetailResponseDto.java
+++ b/src/main/java/doritos/doriroom/user/dto/response/UserMyPageInfoDetailResponseDto.java
@@ -1,0 +1,39 @@
+package doritos.doriroom.user.dto.response;
+
+import doritos.doriroom.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.util.UUID;
+
+@Builder
+public record UserMyPageInfoDetailResponseDto(
+        @Schema(description = "사용자 ID", example = "43d1a5a2-58dc-4786-8dba-27c62cae1943")
+        UUID userId,
+
+        @Schema(description = "사용자 프로필 이미지")
+        String profileImageUrl,
+
+        @Schema(description = "사용자 닉네임", example = "도리토스")
+        String nickname,
+
+        @Schema(description = "사용자 아이디", example = "user1234")
+        String username,
+
+        @Schema(description = "사용자 이메일", example = "user@example.com")
+        String email
+
+) {
+    public static UserMyPageInfoDetailResponseDto from(User user) {
+        if (user == null) {
+            return null;
+        }
+        return UserMyPageInfoDetailResponseDto.builder()
+                .userId(user.getUserId())
+                .profileImageUrl(user.getProfileImageUrl())
+                .nickname(user.getNickname())
+                .username(user.getUsername())
+                .email(user.getEmail())
+                .build();
+    }
+}

--- a/src/main/java/doritos/doriroom/user/dto/response/UserMyPageInfoResponseDto.java
+++ b/src/main/java/doritos/doriroom/user/dto/response/UserMyPageInfoResponseDto.java
@@ -1,0 +1,32 @@
+package doritos.doriroom.user.dto.response;
+
+import doritos.doriroom.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.util.UUID;
+
+
+@Builder
+public record UserMyPageInfoResponseDto(
+        @Schema(description = "사용자 ID", example = "43d1a5a2-58dc-4786-8dba-27c62cae1943")
+        UUID userId,
+
+        @Schema(description = "사용자 닉네임", example = "도리토스")
+        String nickname,
+
+        @Schema(description = "사용자 프로필 이미지")
+        String profileImageUrl
+
+) {
+    public static UserMyPageInfoResponseDto from(User user) {
+        if (user == null) {
+            return null;
+        }
+        return UserMyPageInfoResponseDto.builder()
+                .userId(user.getUserId())
+                .nickname(user.getNickname())
+                .profileImageUrl(user.getProfileImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/doritos/doriroom/user/exception/UserNotFoundException.java
+++ b/src/main/java/doritos/doriroom/user/exception/UserNotFoundException.java
@@ -3,8 +3,8 @@ package doritos.doriroom.user.exception;
 import doritos.doriroom.global.exception.ApiException;
 import org.springframework.http.HttpStatus;
 
-public class UsernameNotFoundException extends ApiException {
-    public UsernameNotFoundException() {
+public class UserNotFoundException extends ApiException {
+    public UserNotFoundException() {
         super(HttpStatus.NOT_FOUND, "해당 유저가 없습니다.");
     }
 }

--- a/src/main/java/doritos/doriroom/user/repository/UserRepository.java
+++ b/src/main/java/doritos/doriroom/user/repository/UserRepository.java
@@ -15,9 +15,9 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     boolean existsByUsername(String username);
     boolean existsByNickname(String nickname);
     boolean existsByEmail(String email);
-
-    // 로그인 시 유저 조회
-    Optional<User> findByUsername(String username);
+    
+    Optional<User> findByUsername(String username); // 로그인 시 유저 조회
+    Optional<User> findByUserId(UUID userId);
 
     @Query("SELECT u FROM User u WHERE u.userId IN :userIds")
     List<User> findByUserIdIn(@Param("userIds") List<UUID> userIds);

--- a/src/main/java/doritos/doriroom/user/service/UserService.java
+++ b/src/main/java/doritos/doriroom/user/service/UserService.java
@@ -1,14 +1,29 @@
 package doritos.doriroom.user.service;
 
+import doritos.doriroom.auth.exception.InvalidPasswordException;
+import doritos.doriroom.s3.S3Uploader;
+import doritos.doriroom.user.domain.User;
+import doritos.doriroom.user.dto.request.ChangePasswordRequestDto;
+import doritos.doriroom.user.dto.request.UpdateProfileRequestDto;
+import doritos.doriroom.user.dto.response.ProfileImageResponseDto;
+import doritos.doriroom.user.dto.response.UserMyPageInfoDetailResponseDto;
+import doritos.doriroom.user.dto.response.UserMyPageInfoResponseDto;
 import doritos.doriroom.user.exception.DuplicateException;
+import doritos.doriroom.user.exception.UsernameNotFoundException;
 import doritos.doriroom.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
+    private final PasswordEncoder encoder;
+    private final S3Uploader s3Uploader;
 
     public void checkUsernameDuplicate(String username){
         if (userRepository.existsByUsername(username)) {
@@ -21,4 +36,79 @@ public class UserService {
         }
     }
 
+    // 내 정보 조회 (마이페이지)
+    @Transactional(readOnly = true)
+    public UserMyPageInfoResponseDto getUserInfo(User user){
+        User foundUser = userRepository.findByUserId(user.getUserId())
+                .orElseThrow(UsernameNotFoundException::new);
+
+        return UserMyPageInfoResponseDto.from(foundUser);
+    }
+
+    // 내 정보 조회 (수정 페이지)
+    @Transactional(readOnly = true)
+    public UserMyPageInfoDetailResponseDto getUserInfoDetail(User user){
+        User foundUser = userRepository.findByUserId(user.getUserId())
+                .orElseThrow(UsernameNotFoundException::new);
+
+        return UserMyPageInfoDetailResponseDto.from(foundUser);
+    }
+
+    // 닉네임 변경
+    @Transactional
+    public void updateProfile(User user, UpdateProfileRequestDto request){
+        User foundUser = userRepository.findByUserId(user.getUserId())
+                .orElseThrow(UsernameNotFoundException::new);
+
+        if (!foundUser.getNickname().equals(request.nickname())){ // 닉네임 변경 여부 확인
+            checkNicknameDuplicate(request.nickname()); // 닉네임 중복 검사
+        }
+
+        foundUser.setNickname(request.nickname()); // 닉네임 업데이트
+    }
+
+    // 프로필 이미지 변경
+    @Transactional
+    public ProfileImageResponseDto uploadProfileImage(User user, MultipartFile file){
+        User foundUser = userRepository.findByUserId(user.getUserId())
+                .orElseThrow(UsernameNotFoundException::new);
+
+        if (StringUtils.hasText(foundUser.getProfileImageUrl())) { // 기존 프로필 이미지가 있으면, s3에서 삭제
+            s3Uploader.deleteFile(foundUser.getProfileImageUrl());
+        }
+
+        String profileImageUrl = s3Uploader.uploadFile(file, "profile_image"); // s3에 업로드 후 url 반환
+
+        foundUser.setProfileImageUrl(profileImageUrl); // 새 이미지 url 반영
+
+        return new ProfileImageResponseDto(profileImageUrl);
+    }
+
+    // 프로필 이미지 삭제
+    @Transactional
+    public void deleteProfileImage(User user){
+        User foundUser = userRepository.findByUserId(user.getUserId())
+                .orElseThrow(UsernameNotFoundException::new);
+
+        if (StringUtils.hasText(foundUser.getProfileImageUrl())) { // 기존 프로필 이미지가 있는지 확인 없으면 수행하지 않음
+            s3Uploader.deleteFile(foundUser.getProfileImageUrl()); // s3에서 삭제
+            foundUser.setProfileImageUrl(null); // DB에서 삭제
+        }
+    }
+
+    // 비밀번호 변경
+    @Transactional
+    public void changePassword(User user, ChangePasswordRequestDto request) {
+        User foundUser = userRepository.findByUserId(user.getUserId())
+                .orElseThrow(UsernameNotFoundException::new);
+
+        if (!encoder.matches(request.currentPassword(), foundUser.getPassword())){ // 기존 비밀번호와 현재 입력한 비밀번호가 일치한지 확인
+            throw new InvalidPasswordException("현재 비밀번호가 일치하지 않습니다.");
+        }
+        if (!request.newPassword().equals(request.confirmPassword())){
+            throw new InvalidPasswordException("새 비밀번호가 일치하지 않습니다.");
+        }
+
+        foundUser.setPassword(encoder.encode(request.newPassword())); // 새 비밀번호를 암호화하여 저장
+    }
 }

--- a/src/main/java/doritos/doriroom/user/service/UserService.java
+++ b/src/main/java/doritos/doriroom/user/service/UserService.java
@@ -9,7 +9,7 @@ import doritos.doriroom.user.dto.response.ProfileImageResponseDto;
 import doritos.doriroom.user.dto.response.UserMyPageInfoDetailResponseDto;
 import doritos.doriroom.user.dto.response.UserMyPageInfoResponseDto;
 import doritos.doriroom.user.exception.DuplicateException;
-import doritos.doriroom.user.exception.UsernameNotFoundException;
+import doritos.doriroom.user.exception.UserNotFoundException;
 import doritos.doriroom.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -40,7 +40,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public UserMyPageInfoResponseDto getUserInfo(User user){
         User foundUser = userRepository.findByUserId(user.getUserId())
-                .orElseThrow(UsernameNotFoundException::new);
+                .orElseThrow(UserNotFoundException::new);
 
         return UserMyPageInfoResponseDto.from(foundUser);
     }
@@ -49,7 +49,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public UserMyPageInfoDetailResponseDto getUserInfoDetail(User user){
         User foundUser = userRepository.findByUserId(user.getUserId())
-                .orElseThrow(UsernameNotFoundException::new);
+                .orElseThrow(UserNotFoundException::new);
 
         return UserMyPageInfoDetailResponseDto.from(foundUser);
     }
@@ -58,7 +58,7 @@ public class UserService {
     @Transactional
     public void updateProfile(User user, UpdateProfileRequestDto request){
         User foundUser = userRepository.findByUserId(user.getUserId())
-                .orElseThrow(UsernameNotFoundException::new);
+                .orElseThrow(UserNotFoundException::new);
 
         if (!foundUser.getNickname().equals(request.nickname())){ // 닉네임 변경 여부 확인
             checkNicknameDuplicate(request.nickname()); // 닉네임 중복 검사
@@ -71,7 +71,7 @@ public class UserService {
     @Transactional
     public ProfileImageResponseDto uploadProfileImage(User user, MultipartFile file){
         User foundUser = userRepository.findByUserId(user.getUserId())
-                .orElseThrow(UsernameNotFoundException::new);
+                .orElseThrow(UserNotFoundException::new);
 
         if (StringUtils.hasText(foundUser.getProfileImageUrl())) { // 기존 프로필 이미지가 있으면, s3에서 삭제
             s3Uploader.deleteFile(foundUser.getProfileImageUrl());
@@ -88,7 +88,7 @@ public class UserService {
     @Transactional
     public void deleteProfileImage(User user){
         User foundUser = userRepository.findByUserId(user.getUserId())
-                .orElseThrow(UsernameNotFoundException::new);
+                .orElseThrow(UserNotFoundException::new);
 
         if (StringUtils.hasText(foundUser.getProfileImageUrl())) { // 기존 프로필 이미지가 있는지 확인 없으면 수행하지 않음
             s3Uploader.deleteFile(foundUser.getProfileImageUrl()); // s3에서 삭제
@@ -100,7 +100,7 @@ public class UserService {
     @Transactional
     public void changePassword(User user, ChangePasswordRequestDto request) {
         User foundUser = userRepository.findByUserId(user.getUserId())
-                .orElseThrow(UsernameNotFoundException::new);
+                .orElseThrow(UserNotFoundException::new);
 
         if (!encoder.matches(request.currentPassword(), foundUser.getPassword())){ // 기존 비밀번호와 현재 입력한 비밀번호가 일치한지 확인
             throw new InvalidPasswordException("현재 비밀번호가 일치하지 않습니다.");


### PR DESCRIPTION
## #️⃣연관된 이슈

#28 

## 📝작업 내용

- 추가된 API
    - 마이페이지 조회/ 마이페이지 상세 조회
    - 프로필 정보 변경(닉네임)
    - 프로필 이미지 변경/ 프로필 이미지 삭제
    - 비밀번호 변경

## 참고사항

기존의 `UsernameNotFoundException`을 `UserNotFoundException`로 명칭을 변경하였습니다.

## 💬리뷰 요구사항(선택)

회원탈퇴 API는 따로 분리하여 후순위로 개발하겠습니다!
기존 비밀번호 틀릴 시 비밀번호 찾기를 위한 이메일 인증 수단을 추가하면 좋을까요? (현재 피그마에 명시된 부분이 없어서 추가하지 않았습니다)