### PR TITLE
Feat/59 diary point

### DIFF
--- a/src/main/java/doritos/doriroom/diary/controller/DiaryController.java
+++ b/src/main/java/doritos/doriroom/diary/controller/DiaryController.java
@@ -154,13 +154,14 @@ public class DiaryController {
         return ApiResponse.ok(response);
     }
 
-    @Operation(summary = "특정 유저의 공개 일기 조회", description = "특정 유저가 작성한 공개 일기 목록을 페이징하여 조회합니다.")
+    @Operation(summary = "특정 유저의 일기 목록 조회", description = "특정 유저가 작성한 일기 목록을 페이징하여 조회합니다. userId가 자신이면 public, follow, private 모든 일기 조회. 자신이 아니면 public 조회")
     @GetMapping("/user/{userId}")
     public ApiResponse<Page<DiaryResponseDto>> getUserPublicDiaries(
         @PathVariable @Schema(description = "유저 ID", example = "43d1a5a2-58dc-4786-8dba-27c62cae1943")
         UUID userId,
+        @AuthenticationPrincipal User user,
         @ParameterObject Pageable pageable) {
-        Page<DiaryResponseDto> response = diaryService.getUserDiaries(userId, pageable);
+        Page<DiaryResponseDto> response = diaryService.getUserDiaries(user.getUserId(), userId, pageable);
         return ApiResponse.ok(response);
     }
 }

--- a/src/main/java/doritos/doriroom/diary/controller/DiaryController.java
+++ b/src/main/java/doritos/doriroom/diary/controller/DiaryController.java
@@ -104,24 +104,15 @@ public class DiaryController {
         return ApiResponse.ok(response);
     }
 
-    @Operation(summary = "자신의 월별 일기 작성 여부 조회", description = "특정 월의 자신의 일기 작성 여부를 일별로 조회합니다.")
-    @GetMapping("/writing-status")
-    public ApiResponse<DiaryWritingStatusResponseDto> getMonthlyWritingStatus(
-        @AuthenticationPrincipal User user,
-        @RequestParam int year,
-        @RequestParam int month) {
-        DiaryWritingStatusResponseDto response = diaryService.getDiaryWritingStatus(user.getUserId(), year, month);
-        return ApiResponse.ok(response);
-    }
-
-    @Operation(summary = "다른 유저의 월별 일기 작성 여부 조회", description = "특정 유저의 public 일기 작성 여부를 일별로 조회합니다.")
+    @Operation(summary = "월별 일기 작성 여부 조회", description = "특정 유저의 일기 작성 여부를 일별로 조회합니다.")
     @GetMapping("/user/{userId}/writing-status")
     public ApiResponse<DiaryWritingStatusResponseDto> getUserMonthlyWritingStatus(
+        @AuthenticationPrincipal User user,
         @PathVariable @Schema(description = "유저 ID", example = "550e8400-e29b-41d4-a716-446655440001")
         UUID userId,
         @RequestParam int year,
         @RequestParam int month) {
-        DiaryWritingStatusResponseDto response = diaryService.getOtherUserDiaryWritingStatus(userId, year, month);
+        DiaryWritingStatusResponseDto response = diaryService.getUserDiaryWritingStatus(user.getUserId(), userId, year, month);
         return ApiResponse.ok(response);
     }
 

--- a/src/main/java/doritos/doriroom/diary/controller/DiaryController.java
+++ b/src/main/java/doritos/doriroom/diary/controller/DiaryController.java
@@ -40,21 +40,7 @@ public class DiaryController {
         @RequestPart("diary") @Valid DiaryCreateRequestDto request,
         @RequestPart(value = "images", required = false) List<MultipartFile> images) {
 
-        // 이미지가 있으면 S3에 업로드
-        List<String> imageUrls = new ArrayList<>();
-        if (images != null && !images.isEmpty()) {
-            imageUrls = s3Uploader.uploadFiles(images, "diary");
-        }
-
-        DiaryCreateRequestDto requestWithImages = new DiaryCreateRequestDto(
-            request.eventId(),
-            request.visitedAt(),
-            imageUrls,
-            request.content(),
-            request.visibility()
-        );
-
-        DiaryResponseDto response = diaryService.createDiary(user.getUserId(), requestWithImages);
+        DiaryResponseDto response = diaryService.createDiary(user, request, images);
         return ApiResponse.ok(response);
     }
 

--- a/src/main/java/doritos/doriroom/diary/domain/Diary.java
+++ b/src/main/java/doritos/doriroom/diary/domain/Diary.java
@@ -64,11 +64,11 @@ public class Diary {
         }
     }
 
-    public static Diary from(UUID userId, DiaryCreateRequestDto request){
+    public static Diary from(UUID userId, DiaryCreateRequestDto request, List<String> imageUrls){
         return Diary.builder()
             .diaryId(UUID.randomUUID())
             .content(request.content())
-            .imageUrls(request.imageUrls())
+            .imageUrls(imageUrls)
             .diaryVisibility(request.visibility())
             .likes(0)
             .visitedAt(request.visitedAt())

--- a/src/main/java/doritos/doriroom/diary/dto/request/DiaryCreateRequestDto.java
+++ b/src/main/java/doritos/doriroom/diary/dto/request/DiaryCreateRequestDto.java
@@ -21,9 +21,6 @@ public record DiaryCreateRequestDto(
     @PastOrPresent(message = "방문 날짜는 과거 또는 현재 날짜여야 합니다.")
     LocalDate visitedAt,
 
-    @Schema(description = "업로드할 이미지 파일들", type = "array")
-    List<String> imageUrls,
-
     @Schema(description = "일기 내용", example = "오늘 축제에 다녀왔습니다. 정말 즐거웠어요!")
     @NotBlank(message = "내용을 입력해주세요.")
     @Size(max = 500, message = "일기 내용은 500자를 초과할 수 없습니다.")
@@ -33,15 +30,4 @@ public record DiaryCreateRequestDto(
     RoomVisibility visibility
 
 ) {
-    public DiaryCreateRequestDto {
-        if (imageUrls == null || imageUrls.isEmpty()) {
-            imageUrls = List.of();
-        } else {
-            imageUrls = imageUrls.stream()
-                .filter(url -> url != null && !url.trim().isEmpty())
-                .distinct() // 중복 제거
-                .limit(5)   // 최대 5개로 제한
-                .toList();
-        }
-    }
-} 
+}

--- a/src/main/java/doritos/doriroom/diary/dto/response/DiaryWritingStatusResponseDto.java
+++ b/src/main/java/doritos/doriroom/diary/dto/response/DiaryWritingStatusResponseDto.java
@@ -14,16 +14,36 @@ public record DiaryWritingStatusResponseDto(
     @Schema(description = "조회 월 (1-12)", example = "8")
     int month,
 
-    @Schema(description = "일별 작성 여부 (키: 일, 값: 작성 여부)",
-        example = "{\"1\": false, \"2\": true, \"3\": false, \"4\": true, \"5\": false}")
-    Map<String, Boolean> dailyStatus
+    @Schema(description = "일별 작성 상태 정보")
+    Map<String, DailyStatusInfo> dailyStatus
 ) {
-    public static DiaryWritingStatusResponseDto from(UUID userId, int year, int month, Map<String, Boolean> dailyStatus) {
+    public record DailyStatusInfo(
+        @Schema(description = "일기 작성 여부", example = "true")
+        boolean isWritten,
+
+        @Schema(description = "대표 이미지 URL (일기가 없거나 이미지가 없는 경우 null)",
+            example = "http://example.com", nullable = true)
+        String imageUrl
+    ) {
+
+        public static DailyStatusInfo notWritten() {
+            return new DailyStatusInfo(false, null);
+        }
+
+        public static DailyStatusInfo writtenWithoutImage() {
+            return new DailyStatusInfo(true, null);
+        }
+
+        public static DailyStatusInfo writtenWithImage(String imageUrl) {
+            return new DailyStatusInfo(true, imageUrl);
+        }
+    }
+    public static DiaryWritingStatusResponseDto from(UUID userId, int year, int month, Map<String, DailyStatusInfo> dailyStatusMap) {
         return new DiaryWritingStatusResponseDto(
             userId,
             year,
             month,
-            dailyStatus
+            dailyStatusMap
         );
     }
 }

--- a/src/main/java/doritos/doriroom/diary/exception/DuplicateDiaryException.java
+++ b/src/main/java/doritos/doriroom/diary/exception/DuplicateDiaryException.java
@@ -1,0 +1,10 @@
+package doritos.doriroom.diary.exception;
+
+import doritos.doriroom.global.exception.ApiException;
+import org.springframework.http.HttpStatus;
+
+public class DuplicateDiaryException extends ApiException {
+    public DuplicateDiaryException(){
+        super(HttpStatus.BAD_REQUEST, "이미 해당 축제에 일기를 작성했습니다.");
+    }
+}

--- a/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
+++ b/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
@@ -35,4 +35,6 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
         @Param("userId") UUID userId,
         @Param("startDate") LocalDate startDate,
         @Param("endDate") LocalDate endDate);
+
+    boolean existsByUserIdAndEventId(UUID userId, UUID eventId);
 }

--- a/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
+++ b/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
@@ -37,4 +37,7 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
         @Param("endDate") LocalDate endDate);
 
     boolean existsByUserIdAndEventId(UUID userId, UUID eventId);
+
+    Page<Diary> findByUserIdOrderByVisitedAtDesc(UUID userId, Pageable pageable);
+
 }

--- a/src/main/java/doritos/doriroom/diary/service/DiaryService.java
+++ b/src/main/java/doritos/doriroom/diary/service/DiaryService.java
@@ -237,33 +237,17 @@ public class DiaryService {
     }
 
     //특정 유저의 일기 목록 조회
-    public Page<DiaryResponseDto> getUserDiaries(UUID userId, Pageable pageable) {
-        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+    public Page<DiaryResponseDto> getUserDiaries(UUID currentUserId, UUID targetUserId, Pageable pageable) {
+        User targetUser = userRepository.findById(targetUserId).orElseThrow(UserNotFoundException::new);
 
-        Page<Diary> diaries = diaryRepository.findPublicByUserIdOrderByVisitedAtDesc(userId, pageable);
+        //자신의 일기인지 확인
+        boolean isOwnDiary = currentUserId.equals(targetUserId);
 
-        if (diaries.isEmpty()) {
-            return Page.empty(pageable);
-        }
+        Page<Diary> diaries = isOwnDiary ?
+            diaryRepository.findByUserIdOrderByVisitedAtDesc(targetUserId, pageable) :
+            diaryRepository.findPublicByUserIdOrderByVisitedAtDesc(targetUserId, pageable);
 
-        List<UUID> eventIds = diaries.getContent().stream()
-            .map(Diary::getEventId)
-            .distinct()
-            .toList();
-
-        Map<UUID, Event> eventMap = eventRepository.findByEventIdIn(eventIds).stream()
-            .collect(Collectors.toMap(Event::getEventId, event -> event));
-
-        // Page의 content만 변환하고 Page 객체는 유지
-        List<DiaryResponseDto> diaryResponseList = diaries.getContent().stream()
-            .map(diary -> {
-                Event event = eventMap.get(diary.getEventId());
-                return DiaryResponseDto.from(diary, user, event);
-            })
-            .toList();
-
-        // 새로운 Page 객체 생성
-        return new PageImpl<>(diaryResponseList, pageable, diaries.getTotalElements());
+        return createDiaryResponsePage(diaries, targetUser, pageable);
     }
 
     public Diary getDiaryById(UUID diaryId) {
@@ -281,4 +265,32 @@ public class DiaryService {
 
         return credit;
     }
+
+    //자신의 일기 조회
+    private Page<DiaryResponseDto> createDiaryResponsePage(Page<Diary> diaries, User user, Pageable pageable) {
+        if (diaries.isEmpty()) {
+            return Page.empty(pageable);
+        }
+
+        // 이벤트 정보 조회
+        List<UUID> eventIds = diaries.getContent().stream()
+            .map(Diary::getEventId)
+            .distinct()
+            .toList();
+
+        Map<UUID, Event> eventMap = eventRepository.findByEventIdIn(eventIds).stream()
+            .collect(Collectors.toMap(Event::getEventId, event -> event));
+
+        // DiaryResponseDto로 변환
+        List<DiaryResponseDto> diaryResponseList = diaries.getContent().stream()
+            .map(diary -> {
+                Event event = eventMap.get(diary.getEventId());
+                return DiaryResponseDto.from(diary, user, event);
+            })
+            .toList();
+
+        return new PageImpl<>(diaryResponseList, pageable, diaries.getTotalElements());
+    }
+
+
 }

--- a/src/main/java/doritos/doriroom/diary/service/DiaryService.java
+++ b/src/main/java/doritos/doriroom/diary/service/DiaryService.java
@@ -138,56 +138,46 @@ public class DiaryService {
     }
 
     //월별 일기 작성 여부 조회
-    public DiaryWritingStatusResponseDto getDiaryWritingStatus(UUID userId, int year, int month) {
-        // 해당 월의 시작일과 종료일 계산
-        LocalDate startDate = LocalDate.of(year, month, 1);
-        LocalDate endDate = startDate.plusMonths(1).minusDays(1);
-
-        List<Diary> diaries = diaryRepository.findByUserIdAndVisitedAtBetweenOrderByVisitedAt(
-            userId, startDate, endDate);
-
-        return createDiaryWritingStatus(userId, year, month, diaries);
-    }
-
-    //다른 유저의 월별 일기 작성 여부 조회
-    public DiaryWritingStatusResponseDto getOtherUserDiaryWritingStatus(UUID userId, int year, int month) {
-        userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
-
-        // 해당 월의 시작일과 종료일 계산
-        LocalDate startDate = LocalDate.of(year, month, 1);
-        LocalDate endDate = startDate.plusMonths(1).minusDays(1);
-
-        /**
-         * 추후 여기에 follow 관계인지 확인하는 로직 추가
-         * 현재는 다른 유저의 public 일기만 조회
-         */
-
-        // 해당 월에 작성된 public 일기만 조회
-        List<Diary> diaries = diaryRepository.findPublicByUserIdAndVisitedAtBetweenOrderByVisitedAt(
-            userId, startDate, endDate);
-
-        return createDiaryWritingStatus(userId, year, month, diaries);
-    }
-
-    // 일기 작성 여부 상태 생성 공통 메서드
-    private DiaryWritingStatusResponseDto createDiaryWritingStatus(UUID userId, int year, int month, List<Diary> diaries) {
-        Map<String, Boolean> dailyStatus = new HashMap<>();
+    public DiaryWritingStatusResponseDto getUserDiaryWritingStatus(UUID currentUserId, UUID targetUserId, int year, int month) {
+        boolean isOwner = currentUserId.equals(targetUserId);
 
         LocalDate startDate = LocalDate.of(year, month, 1);
-        int daysInMonth = startDate.lengthOfMonth();
+        int lastDayOfMonth = startDate.lengthOfMonth();
+        LocalDate endDate = LocalDate.of(year, month, lastDayOfMonth);
 
-        // 모든 일을 false로 초기화
-        for (int day = 1; day <= daysInMonth; day++) {
-            dailyStatus.put(String.valueOf(day), false);
+        List<Diary> diaries;
+        if (isOwner) {
+            // 자신의 일기: 모든 공개 범위의 일기를 조회
+            diaries = diaryRepository.findByUserIdAndVisitedAtBetweenOrderByVisitedAt(
+                targetUserId, startDate, endDate);
+        } else {
+            // 다른 사용자의 일기: PUBLIC 일기만 조회
+            diaries = diaryRepository.findPublicByUserIdAndVisitedAtBetweenOrderByVisitedAt(
+                targetUserId, startDate, endDate);
         }
 
-        // 작성된 일기를 true로 설정
+        // 해당 월의 모든 날짜에 대해 초기화
+        Map<String, DiaryWritingStatusResponseDto.DailyStatusInfo> dailyStatusMap = new LinkedHashMap<>();
+        for (int day = 1; day <= lastDayOfMonth; day++) {
+            dailyStatusMap.put(String.valueOf(day), DiaryWritingStatusResponseDto.DailyStatusInfo.notWritten());
+        }
+
+        // 조회된 일기 정보를 바탕으로 상태 업데이트
         for (Diary diary : diaries) {
-            int day = diary.getVisitedAt().getDayOfMonth();
-            dailyStatus.put(String.valueOf(day), true);
+            String dayKey = String.valueOf(diary.getVisitedAt().getDayOfMonth());
+
+            String representativeImageUrl = null;
+            if (diary.getImageUrls() != null && !diary.getImageUrls().isEmpty()) {
+                representativeImageUrl = diary.getImageUrls().get(0);
+            }
+
+            dailyStatusMap.put(
+                dayKey,
+                new DiaryWritingStatusResponseDto.DailyStatusInfo(true, representativeImageUrl)
+            );
         }
 
-        return DiaryWritingStatusResponseDto.from(userId, year, month, dailyStatus);
+        return DiaryWritingStatusResponseDto.from(targetUserId, year, month, dailyStatusMap);
     }
 
     //일별 작성한 일기 목록 조회

--- a/src/main/java/doritos/doriroom/diary/service/DiaryService.java
+++ b/src/main/java/doritos/doriroom/diary/service/DiaryService.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Transactional(readOnly = true)
@@ -37,26 +38,35 @@ public class DiaryService {
     private static final int PHOTO_ATTACHMENT_BONUS_CREDIT = 5;
 
     @Transactional
-    public DiaryResponseDto createDiary(UUID userId, DiaryCreateRequestDto request){
-        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+    public DiaryResponseDto createDiary(User user, DiaryCreateRequestDto request, List<MultipartFile> images){
+        userRepository.findById(user.getUserId()).orElseThrow(UserNotFoundException::new);
+
         Event event = eventRepository.findById(request.eventId()).orElseThrow(EventNotFoundException::new);
 
-        boolean alreadyWroteDiary = diaryRepository.existsByUserIdAndEventId(userId, request.eventId());
+        boolean alreadyWroteDiary = diaryRepository.existsByUserIdAndEventId(user.getUserId(), request.eventId());
         if (alreadyWroteDiary) {
             throw new DuplicateDiaryException();
         }
 
-        Diary diary = Diary.from(userId, request);
+        //S3에 이미지 업로드
+        List<String> imageUrls = new ArrayList<>();
+        if (images != null && !images.isEmpty()) {
+            String path = "diary/" + user.getUserId().toString();
+            imageUrls = s3Uploader.uploadFiles(images, path);
+        }
+
+        Diary diary = Diary.from(user.getUserId(), request, imageUrls);
 
         //축제의 일기 count 증가
         if (request.visibility() == RoomVisibility.PUBLIC) {
             event.incrementDiaryCount();
             eventRepository.save(event);
         }
+
         diaryRepository.save(diary);
 
         // 포인트 지급
-        int totalCredit = calculateDiaryCredit(request.imageUrls());
+        int totalCredit = calculateDiaryCredit(imageUrls);
         user.addCredit(totalCredit);
         userRepository.save(user);
 

--- a/src/main/java/doritos/doriroom/diary/service/DiaryService.java
+++ b/src/main/java/doritos/doriroom/diary/service/DiaryService.java
@@ -33,6 +33,9 @@ public class DiaryService {
     private final EventRepository eventRepository;
     private final S3Uploader s3Uploader;
 
+    private static final int DIARY_WRITE_BASE_CREDIT = 10;
+    private static final int PHOTO_ATTACHMENT_BONUS_CREDIT = 5;
+
     @Transactional
     public DiaryResponseDto createDiary(UUID userId, DiaryCreateRequestDto request){
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
@@ -46,6 +49,11 @@ public class DiaryService {
             eventRepository.save(event);
         }
         diaryRepository.save(diary);
+
+        // 포인트 지급
+        int totalCredit = calculateDiaryCredit(request.imageUrls());
+        user.addCredit(totalCredit);
+        userRepository.save(user);
 
         return DiaryResponseDto.from(diary, user, event);
     }
@@ -256,5 +264,16 @@ public class DiaryService {
     public Diary getDiaryById(UUID diaryId) {
         return diaryRepository.findById(diaryId)
             .orElseThrow(DiaryNotFoundException::new);
+    }
+
+    //일기 작성 시 포인트 지급
+    private int calculateDiaryCredit(List<String> imageUrls) {
+        int credit = DIARY_WRITE_BASE_CREDIT;
+
+        if (imageUrls != null && !imageUrls.isEmpty()) {
+            credit += PHOTO_ATTACHMENT_BONUS_CREDIT;
+        }
+
+        return credit;
     }
 }

--- a/src/main/java/doritos/doriroom/diary/service/DiaryService.java
+++ b/src/main/java/doritos/doriroom/diary/service/DiaryService.java
@@ -41,6 +41,11 @@ public class DiaryService {
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
         Event event = eventRepository.findById(request.eventId()).orElseThrow(EventNotFoundException::new);
 
+        boolean alreadyWroteDiary = diaryRepository.existsByUserIdAndEventId(userId, request.eventId());
+        if (alreadyWroteDiary) {
+            throw new DuplicateDiaryException();
+        }
+
         Diary diary = Diary.from(userId, request);
 
         //축제의 일기 count 증가

--- a/src/main/java/doritos/doriroom/user/domain/User.java
+++ b/src/main/java/doritos/doriroom/user/domain/User.java
@@ -44,6 +44,11 @@ public class User {
     @Column(nullable = false)
     private int viewCount = 0;
 
+    // 포인트 관련 메서드 추가
+    public void addCredit(int credit) {
+        this.credit += credit;
+    }
+
     // 보유 크레딧 차감
     public void deductCredit(long price){
         if(this.credit < price){ throw new NotEnoughCreditException();};


### PR DESCRIPTION
## #️⃣연관된 이슈

#59 

## 📝작업 내용
1. 축제 1개당 하나의 일기만 작성 가능
2. 일기 작성 시 기준에 따라 포인트 지급
3. s3의 경로를 diary/userId로 변경
4. 내 일기 전체 조회와 다른 유저 일기 전체 조회 구현
> 기존에 내 일기 전체 조회가 없어서 합쳐서 개발
5. 월별 일기 작성여부 조회 시 대표이미지를 조회하여 응답에 추가 