### PR TITLE
fix: 인기 축제 조회 쿼리 변경

### DIFF
--- a/src/main/java/doritos/doriroom/event/repository/EventRepositoryImpl.java
+++ b/src/main/java/doritos/doriroom/event/repository/EventRepositoryImpl.java
@@ -8,6 +8,7 @@ import doritos.doriroom.event.domain.QEvent;
 import doritos.doriroom.event.domain.QEventFavorite;
 import doritos.doriroom.event.dto.request.EventItemFilterRequestDto;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -61,15 +62,16 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
         QEventFavorite eventFavorite = QEventFavorite.eventFavorite;
 
         LocalDate today = LocalDate.now();
+        LocalDateTime thirtyDaysAgo = LocalDateTime.now().minusDays(30);
 
         return queryFactory
-            .selectFrom(event)
-            .leftJoin(diary).on(diary.eventId.eq(event.eventId))
-            .leftJoin(eventFavorite).on(eventFavorite.event.eventId.eq(event.eventId))
-            .where(
-                event.startDate.loe(today.plusDays(7))  // 시작일 <= 오늘+7일
-                    .and(event.endDate.goe(today.minusDays(7)))  // 종료일 >= 오늘-7일
-            )
+            .select(event)
+            .from(event)
+            .leftJoin(diary).on(diary.eventId.eq(event.eventId)
+                .and(diary.createdAt.goe(thirtyDaysAgo)))
+            .leftJoin(eventFavorite).on(eventFavorite.event.eventId.eq(event.eventId)
+                .and(eventFavorite.createdAt.goe(thirtyDaysAgo)))
+            .where(event.startDate.goe(today))
             .groupBy(event.eventId)
             .orderBy(
                 diary.count().multiply(3)


### PR DESCRIPTION
## #️⃣연관된 이슈

Closes #75 

## 📝작업 내용

1. 최근 뜨는 축제 조회에서 쿼리문을 변경했습니다.
> 30일 이내 축제에서 일기 수, 축제 좋아요 수 가중치