### PR TITLE
Feat/88 tourapi

### DIFF
--- a/src/main/java/doritos/doriroom/DoriroomApplication.java
+++ b/src/main/java/doritos/doriroom/DoriroomApplication.java
@@ -2,10 +2,12 @@ package doritos.doriroom;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableAsync
 public class DoriroomApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/doritos/doriroom/event/domain/Event.java
+++ b/src/main/java/doritos/doriroom/event/domain/Event.java
@@ -103,8 +103,8 @@ public class Event {
     private String polygon;
 
     @Column
-    @Builder.Default
-    private boolean detailUpdated = false;
+    @Enumerated(EnumType.STRING)
+    private EventDetailStatus eventDetailStatus;
 
     public static Event fromEntity(TourApiItemDto dto){
         if (dto.getContentid() == null || dto.getContentid().isBlank()) {
@@ -135,6 +135,8 @@ public class Event {
             .lclsSystm2(dto.getLclsSystm2())
             .lclsSystm3(dto.getLclsSystm3())
             .favoriteCount(0)
+            .diaryCount(0)
+            .eventDetailStatus(EventDetailStatus.PENDING)
             .build();
     }
 
@@ -164,7 +166,6 @@ public class Event {
             this.sponsor1 = dto.getSponsor1();
             this.sponsor2 = dto.getSponsor2();
             this.useTimeFestival = dto.getUsetimefestival();
-            this.detailUpdated = true;
         }
     }
 
@@ -177,9 +178,14 @@ public class Event {
                     this.eventContent = detailInfo.getInfotext();
                 }
             }
-            this.detailUpdated = true;
         }
     }
+
+    // 상태를 변경하는 메서드를 외부에 명확하게 제공
+    public void changeEventDetailStatus(EventDetailStatus status) {
+        this.eventDetailStatus = status;
+    }
+
 
     public void increaseFavoriteCount() {
         this.favoriteCount++;

--- a/src/main/java/doritos/doriroom/event/domain/EventDetailStatus.java
+++ b/src/main/java/doritos/doriroom/event/domain/EventDetailStatus.java
@@ -1,0 +1,8 @@
+package doritos.doriroom.event.domain;
+
+public enum EventDetailStatus {
+    SUCCESS,                    // 성공적으로 업데이트됨
+    FAILED,                     // 업데이트 실패
+    PENDING,                    // 초기 상태
+    DELETED_FROM_API           // TourAPI에서 축제가 삭제됨
+}

--- a/src/main/java/doritos/doriroom/event/repository/EventRepository.java
+++ b/src/main/java/doritos/doriroom/event/repository/EventRepository.java
@@ -1,6 +1,7 @@
 package doritos.doriroom.event.repository;
 
 import doritos.doriroom.event.domain.Event;
+import doritos.doriroom.event.domain.EventDetailStatus;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
@@ -37,12 +38,7 @@ public interface EventRepository extends JpaRepository<Event, UUID>, EventReposi
     """)
     Page<Event> findByAreaCodesIn(@Param("areaCodes") List<Integer> areaCodes, Pageable pageable);
 
-    @Query("""
-    SELECT e FROM Event e
-    WHERE e.detailUpdated = false
-    ORDER BY e.startDate ASC
-    """)
-    List<Event> findEventsNeedingDetailUpdate();
+    List<Event> findByEventDetailStatusOrderByStartDateDesc(EventDetailStatus detailStatus);
 
     @Query("SELECT e FROM Event e WHERE e.eventId IN :eventIds")
     List<Event> findByEventIdIn(@Param("eventIds") List<UUID> eventIds);

--- a/src/main/java/doritos/doriroom/event/repository/EventRepository.java
+++ b/src/main/java/doritos/doriroom/event/repository/EventRepository.java
@@ -19,21 +19,26 @@ public interface EventRepository extends JpaRepository<Event, UUID>, EventReposi
     List<Event> findEventsByContentIds(@Param("contentIds") List<Integer> contentIds);
 
     @Query("""
-    SELECT e FROM Event e
-    WHERE e.startDate >= CURRENT_DATE
-    ORDER BY e.startDate ASC
+        SELECT e FROM Event e
+        WHERE e.startDate >= CURRENT_DATE
+        AND e.eventDetailStatus = 'SUCCESS'
+        ORDER BY e.startDate ASC
     """)
     List<Event> findUpcomingEvents(Pageable pageable);
 
-    @Query("SELECT e FROM Event e " +
-        "WHERE e.startDate <= :today AND e.endDate >= :today " +
-        "ORDER BY e.endDate ASC")
+    @Query("""
+        SELECT e FROM Event e
+        WHERE e.startDate <= :today AND e.endDate >= :today
+        AND e.eventDetailStatus = 'SUCCESS'
+        ORDER BY e.endDate ASC
+    """)
     List<Event> findEndingSoonEvents(@Param("today") LocalDate today, Pageable pageable);
 
     @Query("""
         SELECT e FROM Event e
         WHERE e.areaCode IN :areaCodes
         AND e.endDate >= CURRENT_DATE
+        AND e.eventDetailStatus = 'SUCCESS'
         ORDER BY e.startDate ASC
     """)
     Page<Event> findByAreaCodesIn(@Param("areaCodes") List<Integer> areaCodes, Pageable pageable);

--- a/src/main/java/doritos/doriroom/event/repository/EventRepositoryImpl.java
+++ b/src/main/java/doritos/doriroom/event/repository/EventRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import doritos.doriroom.diary.domain.QDiary;
 import doritos.doriroom.event.domain.Event;
+import doritos.doriroom.event.domain.EventDetailStatus;
 import doritos.doriroom.event.domain.QEvent;
 import doritos.doriroom.event.domain.QEventFavorite;
 import doritos.doriroom.event.dto.request.EventItemFilterRequestDto;
@@ -27,6 +28,7 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
         List<Event> results = queryFactory
             .selectFrom(event)
             .where(
+                isSuccessStatus(event),
                 eqAreaCode(filter.areaCode(), event),
                 eqSigunguCodes(filter.sigunguCodes(), event),
                 eqCategoryCodes(filter.categoryCodes(), event),
@@ -43,6 +45,7 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
             .select(event.count())
             .from(event)
             .where(
+                isSuccessStatus(event),
                 eqAreaCode(filter.areaCode(), event),
                 eqSigunguCodes(filter.sigunguCodes(), event),
                 eqCategoryCodes(filter.categoryCodes(), event),
@@ -71,7 +74,10 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
                 .and(diary.createdAt.goe(thirtyDaysAgo)))
             .leftJoin(eventFavorite).on(eventFavorite.event.eventId.eq(event.eventId)
                 .and(eventFavorite.createdAt.goe(thirtyDaysAgo)))
-            .where(event.startDate.goe(today))
+            .where(
+                isSuccessStatus(event),
+                event.startDate.goe(today)
+            )
             .groupBy(event.eventId)
             .orderBy(
                 diary.count().multiply(3)
@@ -110,5 +116,9 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
     private BooleanExpression eqKeyword(String keyword, QEvent event) {
         return keyword != null && !keyword.trim().isEmpty()
             ? event.title.containsIgnoreCase(keyword) : null;
+    }
+
+    private BooleanExpression isSuccessStatus(QEvent event) {
+        return event.eventDetailStatus.eq(EventDetailStatus.SUCCESS);
     }
 }

--- a/src/main/java/doritos/doriroom/event/service/EventService.java
+++ b/src/main/java/doritos/doriroom/event/service/EventService.java
@@ -1,6 +1,7 @@
 package doritos.doriroom.event.service;
 
 import doritos.doriroom.event.domain.Event;
+import doritos.doriroom.event.domain.EventDetailStatus;
 import doritos.doriroom.event.dto.request.EventItemFilterRequestDto;
 import doritos.doriroom.event.dto.response.EventDetailResponseDto;
 import doritos.doriroom.event.dto.response.EventResponseDto;
@@ -90,37 +91,50 @@ public class EventService {
 
     @Transactional
     public void updateEventDetails() {
-        List<Event> events = eventRepository.findEventsNeedingDetailUpdate();
-        int dailyLimit = 900;
+        List<Event> events = eventRepository.findByEventDetailStatusOrderByStartDateDesc(EventDetailStatus.PENDING);
+        int dailyLimit = 10;
         int processedCount = 0;
 
         log.info("축제 상세정보 업데이트 시작");
 
         for (Event event : events) {
+            EventDetailStatus currentStatus = EventDetailStatus.PENDING;
             if (processedCount >= dailyLimit) {
                 log.info("오늘의 업데이트 한도({}개)에 도달했습니다. 남은 이벤트: {}개", dailyLimit, events.size() - processedCount);
                 break;
             }
 
             try {
-                // detailIntro2 업데이트
+                // detailIntro2, detailInfo2 업데이트
                 TourApiDetailIntroDto detailIntroDto = tourApiService.fetchEventDetailIntro(event.getContentId());
-                event.updateDetailFrom(detailIntroDto);
-                processedCount++;
-
-                // detailInfo2 업데이트
                 List<TourApiDetailInfoDto> detailInfoList = tourApiService.fetchEventDetailInfo(event.getContentId());
-                event.updateDetailInfoFrom(detailInfoList);
-                processedCount++;
+                processedCount += 2;
 
-                eventRepository.save(event);
-
-                // API 호출 간격 조절
-                Thread.sleep(500);
-
+                //API에서 삭제된 경우
+                if (detailIntroDto == null && (detailInfoList == null || detailInfoList.isEmpty())) {
+                    currentStatus = EventDetailStatus.DELETED_FROM_API;
+                    log.warn("API에서 삭제된 이벤트 발견. contentId: {}", event.getContentId());
+                } else {
+                    // 데이터가 있으면 엔티티 업데이트 후 성공 처리
+                    event.updateDetailFrom(detailIntroDto);
+                    event.updateDetailInfoFrom(detailInfoList);
+                    currentStatus = EventDetailStatus.SUCCESS;
+                }
             } catch (Exception e) {
                 log.error("축제 상세정보 업데이트 실패. contentId: {}, error: {}", event.getContentId(), e.getMessage());
                 processedCount += 2;
+            }
+
+            //결정된 상태를 엔티티에 반영하고 저장
+            event.changeEventDetailStatus(currentStatus);
+            eventRepository.save(event);
+
+            try {
+                // API 호출 간격 조절
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.error("Thread sleep 중단됨", e);
             }
         }
         log.info("전체 축제 상세정보 업데이트 완료");
@@ -152,7 +166,7 @@ public class EventService {
             .orElseThrow(EventNotFoundException::new);
 
         //DB에 상세정보가 없으면 tourAPI 호출
-        if(!event.isDetailUpdated()){
+        if(event.getEventDetailStatus() == EventDetailStatus.PENDING){
             try{
                 TourApiDetailIntroDto detailIntroDto = tourApiService.fetchEventDetailIntro(event.getContentId());
                 event.updateDetailFrom(detailIntroDto);

--- a/src/main/java/doritos/doriroom/event/service/EventService.java
+++ b/src/main/java/doritos/doriroom/event/service/EventService.java
@@ -14,6 +14,7 @@ import doritos.doriroom.tourApi.service.TourApiService;
 import doritos.doriroom.event.repository.EventRepository;
 import java.time.LocalDate;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -92,49 +93,54 @@ public class EventService {
     @Transactional
     public void updateEventDetails() {
         List<Event> events = eventRepository.findByEventDetailStatusOrderByStartDateDesc(EventDetailStatus.PENDING);
-        int dailyLimit = 10;
+        int dailyLimit = 900;
         int processedCount = 0;
 
         log.info("축제 상세정보 업데이트 시작");
 
         for (Event event : events) {
-            EventDetailStatus currentStatus = EventDetailStatus.PENDING;
+            EventDetailStatus currentStatus;
             if (processedCount >= dailyLimit) {
                 log.info("오늘의 업데이트 한도({}개)에 도달했습니다. 남은 이벤트: {}개", dailyLimit, events.size() - processedCount);
                 break;
             }
 
-            try {
-                // detailIntro2, detailInfo2 업데이트
-                TourApiDetailIntroDto detailIntroDto = tourApiService.fetchEventDetailIntro(event.getContentId());
-                List<TourApiDetailInfoDto> detailInfoList = tourApiService.fetchEventDetailInfo(event.getContentId());
-                processedCount += 2;
+            if(event.getEventDetailStatus() == EventDetailStatus.PENDING) {
+                try {
+                    // 두 API를 비동기 호출
+                    CompletableFuture<TourApiDetailIntroDto> introFuture = tourApiService.fetchEventDetailIntro(
+                        event.getContentId());
+                    CompletableFuture<List<TourApiDetailInfoDto>> infoFuture = tourApiService.fetchEventDetailInfo(
+                        event.getContentId());
 
-                //API에서 삭제된 경우
-                if (detailIntroDto == null && (detailInfoList == null || detailInfoList.isEmpty())) {
-                    currentStatus = EventDetailStatus.DELETED_FROM_API;
-                    log.warn("API에서 삭제된 이벤트 발견. contentId: {}", event.getContentId());
-                } else {
-                    // 데이터가 있으면 엔티티 업데이트 후 성공 처리
-                    event.updateDetailFrom(detailIntroDto);
-                    event.updateDetailInfoFrom(detailInfoList);
-                    currentStatus = EventDetailStatus.SUCCESS;
+                    // 두 작업이 모두 끝날 때까지 기다림
+                    CompletableFuture.allOf(introFuture, infoFuture).join();
+                    processedCount += 2;
+
+                    // 결과 가져오기
+                    TourApiDetailIntroDto detailIntroDto = introFuture.get();
+                    List<TourApiDetailInfoDto> detailInfoList = infoFuture.get();
+
+                    // API에서 삭제된 경우
+                    if (detailIntroDto == null && (detailInfoList == null
+                        || detailInfoList.isEmpty())) {
+                        currentStatus = EventDetailStatus.DELETED_FROM_API;
+                        log.warn("API에서 삭제된 이벤트 발견. contentId: {}", event.getContentId());
+                    } else {
+                        event.updateDetailFrom(detailIntroDto);
+                        event.updateDetailInfoFrom(detailInfoList);
+                        currentStatus = EventDetailStatus.SUCCESS;
+                    }
+                } catch (Exception e) {
+                    log.error("축제 상세정보 업데이트 실패. contentId: {}, error: {}", event.getContentId(),
+                        e.getMessage());
+                    currentStatus = EventDetailStatus.FAILED;
+                    processedCount += 2;
                 }
-            } catch (Exception e) {
-                log.error("축제 상세정보 업데이트 실패. contentId: {}, error: {}", event.getContentId(), e.getMessage());
-                processedCount += 2;
-            }
 
-            //결정된 상태를 엔티티에 반영하고 저장
-            event.changeEventDetailStatus(currentStatus);
-            eventRepository.save(event);
-
-            try {
-                // API 호출 간격 조절
-                Thread.sleep(500);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                log.error("Thread sleep 중단됨", e);
+                //결정된 상태를 엔티티에 반영하고 저장
+                event.changeEventDetailStatus(currentStatus);
+                eventRepository.save(event);
             }
         }
         log.info("전체 축제 상세정보 업데이트 완료");
@@ -167,18 +173,36 @@ public class EventService {
 
         //DB에 상세정보가 없으면 tourAPI 호출
         if(event.getEventDetailStatus() == EventDetailStatus.PENDING){
+            EventDetailStatus currentStatus;
             try{
-                TourApiDetailIntroDto detailIntroDto = tourApiService.fetchEventDetailIntro(event.getContentId());
-                event.updateDetailFrom(detailIntroDto);
+                // 두 API를 비동기 호출
+                CompletableFuture<TourApiDetailIntroDto> introFuture = tourApiService.fetchEventDetailIntro(event.getContentId());
+                CompletableFuture<List<TourApiDetailInfoDto>> infoFuture = tourApiService.fetchEventDetailInfo(event.getContentId());
 
-                List<TourApiDetailInfoDto> detailInfoDto = tourApiService.fetchEventDetailInfo(event.getContentId());
-                event.updateDetailInfoFrom(detailInfoDto);
+                // 두 작업이 모두 끝날 때까지 기다림
+                CompletableFuture.allOf(introFuture, infoFuture).join();
 
-                eventRepository.save(event);
+                // 결과 가져오기
+                TourApiDetailIntroDto detailIntroDto = introFuture.get();
+                List<TourApiDetailInfoDto> detailInfoList = infoFuture.get();
+
+                // API에서 삭제된 경우
+                if (detailIntroDto == null && (detailInfoList == null || detailInfoList.isEmpty())) {
+                    currentStatus = EventDetailStatus.DELETED_FROM_API;
+                    log.warn("API에서 삭제된 이벤트 발견. contentId: {}", event.getContentId());
+                } else {
+                    currentStatus = EventDetailStatus.SUCCESS;
+                    event.updateDetailFrom(detailIntroDto);
+                    event.updateDetailInfoFrom(detailInfoList);
+                }
             } catch (Exception e){
+                currentStatus = EventDetailStatus.FAILED;
                 log.error("축제 상세 정보 업데이트 실패: eventId={}, error={}", eventId, e.getMessage());
             }
+            event.changeEventDetailStatus(currentStatus);
+            eventRepository.save(event);
         }
+
         return EventDetailResponseDto.from(event);
     }
 

--- a/src/main/java/doritos/doriroom/tourApi/controller/TourApiController.java
+++ b/src/main/java/doritos/doriroom/tourApi/controller/TourApiController.java
@@ -109,6 +109,13 @@ public class TourApiController {
         return ApiResponse.ok("DB에 축제 관련 데이터 저장 완료");
     }
 
+    @Operation(summary = "어제 수정된 축제 정보 받아와서 DB에 반영 (관리자용)")
+    @PostMapping("/update")
+    public ApiResponse<String> update() {
+        eventService.updateTodayEvents();
+        return ApiResponse.ok("DB에 수정된 축제 정보 반영");
+    }
+
     @Operation(
         summary = "전체 축제 상세 정보 초기화 (관리자용)",
         description = """

--- a/src/main/java/doritos/doriroom/tourApi/dto/response/ItemsDeserializer.java
+++ b/src/main/java/doritos/doriroom/tourApi/dto/response/ItemsDeserializer.java
@@ -1,0 +1,86 @@
+package doritos.doriroom.tourApi.dto.response;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import doritos.doriroom.tourApi.dto.response.TourApiResponseDto.Items;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ItemsDeserializer extends JsonDeserializer<Items> {
+    @Override
+    public Items deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+        JsonNode node = jp.getCodec().readTree(jp);
+
+        Items items = new Items();
+
+        //null인 경우
+        if(node == null || node.isNull()) {
+            items.setItem(new ArrayList<>());
+            return items;
+        }
+
+        //빈 문자열인 경우
+        if(node.isTextual() && node.asText().trim().isEmpty()) {
+            items.setItem(new ArrayList<>());
+            return items;
+        }
+
+        //item 필드가 없는 경우
+        if(!node.has("item")){
+            items.setItem(new ArrayList<>());
+            return items;
+        }
+
+        JsonNode itemNode = node.get("item");
+
+        // item이 null이거나 빈 문자열인 경우
+        if (itemNode == null || itemNode.isNull() ||
+            (itemNode.isTextual() && itemNode.asText().trim().isEmpty())) {
+            items.setItem(new ArrayList<>());
+            return items;
+        }
+
+        // item이 배열인 경우
+        if (itemNode.isArray()) {
+            List<TourApiItemDto> itemList = new ArrayList<>();
+            for (JsonNode element : itemNode) {
+                try {
+                    TourApiItemDto item = jp.getCodec().treeToValue(element, TourApiItemDto.class);
+                    if (item != null) {
+                        itemList.add(item);
+                    }
+                } catch (Exception e) {
+                    // 개별 아이템 파싱 실패 시 로그만 남기고 계속 진행
+                    System.err.println("아이템 파싱 실패: " + e.getMessage());
+                }
+            }
+            items.setItem(itemList);
+            return items;
+        }
+
+        // item이 단일 객체인 경우
+        if (itemNode.isObject()) {
+            try {
+                TourApiItemDto item = jp.getCodec().treeToValue(itemNode, TourApiItemDto.class);
+                List<TourApiItemDto> itemList = new ArrayList<>();
+                if (item != null) {
+                    itemList.add(item);
+                }
+                items.setItem(itemList);
+                return items;
+            } catch (Exception e) {
+                System.err.println("단일 아이템 파싱 실패: " + e.getMessage());
+                items.setItem(new ArrayList<>());
+                return items;
+            }
+        }
+
+        // 기타 경우 빈 리스트 반환
+        items.setItem(new ArrayList<>());
+        return items;
+    }
+
+}

--- a/src/main/java/doritos/doriroom/tourApi/dto/response/TourApiResponseDto.java
+++ b/src/main/java/doritos/doriroom/tourApi/dto/response/TourApiResponseDto.java
@@ -1,5 +1,8 @@
 package doritos.doriroom.tourApi.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.Collections;
 import java.util.List;
 import lombok.Data;
 
@@ -21,6 +24,8 @@ public class TourApiResponseDto {
 
     @Data
     public static class TourApiBody{
+        @JsonProperty("items")
+        @JsonDeserialize(using = ItemsDeserializer.class)
         private Items items;
         private long numOfRows;
         private int pageNo;

--- a/src/main/java/doritos/doriroom/tourApi/scheduler/TourApiScheduler.java
+++ b/src/main/java/doritos/doriroom/tourApi/scheduler/TourApiScheduler.java
@@ -13,23 +13,10 @@ public class TourApiScheduler {
 
     private final EventService eventService;
 
-    //DB에 모든 축제 데이터 저장, 추후 스케줄러 시간 변경 필요
-//    @Scheduled(cron = "0 * * * * ?") //1분마다 호출
-    public void schedule() {
-        eventService.getAllEvents();
-    }
-
-    //DB에 오늘 시작하는 축제, 수정날짜 오늘인 데이터 upsert 추후 스케줄러 시간 변경 필요
-//    @Scheduled(cron = "0 * * * * ?") //1분마다 호출
+    //DB에 수정날짜 어제인 데이터 upsert 추후 스케줄러 시간 변경 필요
+    @Scheduled(cron = "0 0 6 * * ?") //매일 새벽 6시 호출
     public void updateEventSchedule(){
         eventService.updateTodayEvents();
-    }
-
-    @Scheduled(cron = "0 0 1 * * ?")  // 매일 새벽 1시에 상세정보 배치 업데이트 (하루에 축제 450개씩)
-    public void updateEventDetailsBatch() {
-        log.info("축제 상세정보 배치 업데이트 시작");
-        eventService.updateEventDetails();
-        log.info("축제 상세정보 배치 업데이트 완료");
     }
 
 }

--- a/src/main/java/doritos/doriroom/tourApi/service/TourApiService.java
+++ b/src/main/java/doritos/doriroom/tourApi/service/TourApiService.java
@@ -1,9 +1,11 @@
 package doritos.doriroom.tourApi.service;
 
 import doritos.doriroom.tourApi.dto.response.*;
+import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,7 +55,8 @@ public class TourApiService {
     }
 
     //특정 축제의 상세정보(detailIntro2) 가져오기 (주관사, 주최사, 가격)
-    public TourApiDetailIntroDto fetchEventDetailIntro(int contentId) {
+    @Async
+    public CompletableFuture<TourApiDetailIntroDto> fetchEventDetailIntro(int contentId) {
         Map<String, String> queryParams = new HashMap<>();
         queryParams.put("contentId", String.valueOf(contentId));
         queryParams.put("contentTypeId", "15");
@@ -67,12 +70,13 @@ public class TourApiService {
             log.warn("축제 상세정보가 없습니다. contentId: {}", contentId);
             return null;
         }
-
-        return response.getResponse().getBody().getItems().getItem().get(0);
+        TourApiDetailIntroDto result = response.getResponse().getBody().getItems().getItem().get(0);
+        return CompletableFuture.completedFuture(result);
     }
 
      //특정 축제의 상세정보(detailInfo2) 가져오기 (행사소개, 행사내용)
-    public List<TourApiDetailInfoDto> fetchEventDetailInfo(int contentId) {
+    @Async
+    public CompletableFuture<List<TourApiDetailInfoDto>> fetchEventDetailInfo(int contentId) {
         Map<String, String> queryParams = new HashMap<>();
         queryParams.put("contentId", String.valueOf(contentId));
         queryParams.put("contentTypeId", "15");
@@ -84,13 +88,13 @@ public class TourApiService {
             response.getResponse().getBody().getItems() == null ||
             response.getResponse().getBody().getItems().getItem().isEmpty()) {
             log.warn("축제 상세정보(detailInfo2)가 없습니다. contentId: {}", contentId);
-            return new ArrayList<>();
+            return CompletableFuture.completedFuture(new ArrayList<>());
         }
 
         List<TourApiDetailInfoDto> items = response.getResponse().getBody().getItems().getItem();
         log.info("축제 상세정보 조회 완료. contentId: {}, 조회된 항목 수: {}", contentId, items.size());
         
-        return items;
+        return CompletableFuture.completedFuture(items);
     }
 
     // 페이징 전체 반복 로직

--- a/src/main/java/doritos/doriroom/tourApi/service/TourApiService.java
+++ b/src/main/java/doritos/doriroom/tourApi/service/TourApiService.java
@@ -35,15 +35,15 @@ public class TourApiService {
         return fetchAllPages(queryParams);
     }
 
-     //오늘 업데이트된 축제 데이터 가져오기
+     //어제 업데이트된 축제 데이터 가져오기
     @Transactional
     public List<TourApiItemDto> fetchTodayEvents() {
-        String today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String yesterday = LocalDate.now().minusDays(1).format(DateTimeFormatter.ofPattern("yyyyMMdd"));
 
         // modifiedtime만 사용하는 호출
         Map<String, String> modifiedParams = new HashMap<>();
         modifiedParams.put("eventStartDate", "20160101");
-        modifiedParams.put("modifiedtime", today);
+        modifiedParams.put("modifiedtime", yesterday);
         List<TourApiItemDto> fromModifiedTime = fetchAllPages(modifiedParams);
 
         log.info("오늘 기준으로 가져온 이벤트: {}건 ( modifiedTime 기반: {})",

--- a/src/main/java/doritos/doriroom/tourApi/service/TourApiService.java
+++ b/src/main/java/doritos/doriroom/tourApi/service/TourApiService.java
@@ -40,36 +40,16 @@ public class TourApiService {
     public List<TourApiItemDto> fetchTodayEvents() {
         String today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
 
-        // eventStartDate만 넣고 호출
-        Map<String, String> startDateParams = new HashMap<>();
-        startDateParams.put("eventStartDate", today);
-        List<TourApiItemDto> fromStartDate = fetchAllPages(startDateParams);
-
         // modifiedtime만 사용하는 호출
         Map<String, String> modifiedParams = new HashMap<>();
         modifiedParams.put("eventStartDate", "20160101");
-        modifiedParams.put("modifiedtime", "20250717");
+        modifiedParams.put("modifiedtime", today);
         List<TourApiItemDto> fromModifiedTime = fetchAllPages(modifiedParams);
 
-        // 3. contentId 기준으로 중복 제거
-        Map<String, TourApiItemDto> merged = new LinkedHashMap<>();
+        log.info("오늘 기준으로 가져온 이벤트: {}건 ( modifiedTime 기반: {})",
+            fromModifiedTime.size(), fromModifiedTime.size());
 
-        for (TourApiItemDto dto : fromStartDate) {
-            if (dto.getContentid() != null && !dto.getContentid().isBlank()) {
-                merged.put(dto.getContentid(), dto);
-            }
-        }
-
-        for (TourApiItemDto dto : fromModifiedTime) {
-            if (dto.getContentid() != null && !dto.getContentid().isBlank()) {
-                merged.put(dto.getContentid(), dto); // 동일 contentId면 덮어씀
-            }
-        }
-
-        log.info("오늘 기준으로 가져온 이벤트: {}건 (startDate 기반: {}, modifiedTime 기반: {})",
-            merged.size(), fromStartDate.size(), fromModifiedTime.size());
-
-        return new ArrayList<>(merged.values());
+        return fromModifiedTime;
     }
 
     //특정 축제의 상세정보(detailIntro2) 가져오기 (주관사, 주최사, 가격)


### PR DESCRIPTION
## #️⃣연관된 이슈

Closes #88 

## 📝작업 내용

1. tourAPI에서 `items: ""`으로 주는 경우 deserialize 처리
2. 상세정보 저장 API 병렬처리
3. 상세정보 저장 실패 여부를 enum으로 세분화
4. 축제 상세정보 업데이트 상태가 SUCCESS인 경우만 조회가능하도록 쿼리문 수정

## 💬리뷰 요구사항(선택)
배포 전에 tourAPI 호출을 admin 계정만 가능하도록 유저에 권한을 부여하는 기능을 구현해야 할 것 같습니다.