### PR TITLE
fix(email): redis 키값 오류로 인한 인증 처리 실패 해결

### DIFF
--- a/src/main/java/doritos/doriroom/auth/service/AuthService.java
+++ b/src/main/java/doritos/doriroom/auth/service/AuthService.java
@@ -58,7 +58,7 @@ public class AuthService {
         String verificationCode = String.format("%06d", new Random().nextInt(1000000)); // 6자리 인증 코드
 
         // redis에 인증 코드 저장
-        String verificationKey = VERIFICATION_KEY_PREFIX + email;
+        String verificationKey = VERIFICATION_KEY_PREFIX.getValue() + email;
         redisTemplate.opsForValue().set(verificationKey, verificationCode, Duration.ofSeconds(VERIFICATION_EXPIRE_SECONDS));
 
         sendEmail(email, verificationCode);


### PR DESCRIPTION
## #️⃣연관된 이슈

#93 

## 📝작업 내용

redis 키값이 일관되지 않아 인증 상태 조회가 불가능한 오류 해결.