### PR TITLE
Feat/102 diary

### DIFF
--- a/src/main/java/doritos/doriroom/diary/controller/DiaryController.java
+++ b/src/main/java/doritos/doriroom/diary/controller/DiaryController.java
@@ -7,6 +7,8 @@ import doritos.doriroom.diary.service.DiaryService;
 import doritos.doriroom.global.dto.ApiResponse;
 import doritos.doriroom.s3.S3Uploader;
 import doritos.doriroom.user.domain.User;
+import doritos.doriroom.user.exception.UserNotFoundException;
+import doritos.doriroom.user.repository.UserRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -32,6 +34,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class DiaryController {
     private final DiaryService diaryService;
     private final S3Uploader s3Uploader;
+    private final UserRepository userRepository;
 
     @Operation(summary = "일기 작성", description = "일기를 작성합니다. '\n' 자세한 내용은 노션 참고해주세요. ")
     @PostMapping(value = "/create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -139,6 +142,16 @@ public class DiaryController {
         @AuthenticationPrincipal User user,
         @ParameterObject Pageable pageable) {
         Page<DiaryResponseDto> response = diaryService.getUserDiaries(user.getUserId(), userId, pageable);
+        return ApiResponse.ok(response);
+    }
+
+    @Operation(summary = "이달의 인기글 조회", description = "현재 월의 인기글을 좋아요 수 기준으로 조회합니다.")
+    @GetMapping("/popular")
+    public ApiResponse<List<DiaryResponseDto>> getPopularDiariesOfMonth(
+        @AuthenticationPrincipal User user
+    ) {
+        userRepository.findById(user.getUserId()).orElseThrow(UserNotFoundException::new);
+        List<DiaryResponseDto> response = diaryService.getPopularDiariesOfMonth();
         return ApiResponse.ok(response);
     }
 }

--- a/src/main/java/doritos/doriroom/diary/controller/DiaryController.java
+++ b/src/main/java/doritos/doriroom/diary/controller/DiaryController.java
@@ -73,7 +73,7 @@ public class DiaryController {
         // 새 이미지 업로드
         List<String> newUrls = new ArrayList<>();
         if (newImages != null && !newImages.isEmpty()) {
-            newUrls = s3Uploader.uploadFiles(newImages, "diary");
+            newUrls = s3Uploader.uploadFiles(newImages, "diary/" + user.getUserId().toString());
         }
 
         // 최종 이미지 목록 = 유지할 것 + 새로 추가한 것

--- a/src/main/java/doritos/doriroom/diary/controller/DiaryController.java
+++ b/src/main/java/doritos/doriroom/diary/controller/DiaryController.java
@@ -154,4 +154,14 @@ public class DiaryController {
         List<DiaryResponseDto> response = diaryService.getPopularDiariesOfMonth();
         return ApiResponse.ok(response);
     }
+
+    @Operation(summary = "친구들 일기 모아보기", description = "팔로우한 친구들의 일기를 시간순으로 조회합니다. 베스트프렌드는 FOLLOWERS 일기도 볼 수 있습니다.")
+    @GetMapping("/friends")
+    public ApiResponse<Page<DiaryResponseDto>> getFriendsDiaries(
+        @AuthenticationPrincipal User user,
+        @ParameterObject Pageable pageable) {
+
+        Page<DiaryResponseDto> response = diaryService.getFriendsDiaries(user.getUserId(), pageable);
+        return ApiResponse.ok(response);
+    }
 }

--- a/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
+++ b/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
@@ -3,6 +3,7 @@ package doritos.doriroom.diary.repository;
 import doritos.doriroom.diary.domain.Diary;
 import doritos.doriroom.user.domain.RoomVisibility;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -53,4 +54,16 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
         @Param("visibilities") List<RoomVisibility> visibilities,
         @Param("startDate") LocalDate startDate,
         @Param("endDate") LocalDate endDate);
+
+    @Query("""
+        SELECT d FROM Diary d
+        WHERE d.diaryVisibility = 'PUBLIC'
+        AND d.createdAt >= :startDate
+        AND d.createdAt <= :endDate
+        ORDER BY (d.likes * 2) DESC, d.createdAt DESC
+        """)
+    List<Diary> findPopularDiariesByMonth(
+        @Param("startDate") LocalDateTime startDate,
+        @Param("endDate") LocalDateTime endDate,
+        Pageable pageable);
 }

--- a/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
+++ b/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
@@ -1,6 +1,7 @@
 package doritos.doriroom.diary.repository;
 
 import doritos.doriroom.diary.domain.Diary;
+import doritos.doriroom.user.domain.RoomVisibility;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
@@ -40,4 +41,16 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
 
     Page<Diary> findByUserIdOrderByVisitedAtDesc(UUID userId, Pageable pageable);
 
+    @Query("""
+        SELECT d FROM Diary d
+        WHERE d.userId = :userId
+        AND d.diaryVisibility IN (:visibilities)
+        AND d.visitedAt BETWEEN :startDate AND :endDate
+        ORDER BY d.visitedAt
+        """)
+    List<Diary> findPublicAndFollowersByUserIdAndVisitedAtBetweenOrderByVisitedAt(
+        @Param("userId") UUID userId,
+        @Param("visibilities") List<RoomVisibility> visibilities,
+        @Param("startDate") LocalDate startDate,
+        @Param("endDate") LocalDate endDate);
 }

--- a/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
+++ b/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
@@ -73,6 +73,7 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
         (d.userId IN :followingIds AND d.diaryVisibility = 'PUBLIC') OR
         (d.userId IN :mutualBestFriendIds AND d.diaryVisibility = 'FOLLOWERS')
     )
+    ORDER BY d.createdAt DESC, d.diaryId DESC
     """)
     Page<Diary> findFriendsDiaries(
         @Param("followingIds") List<UUID> followingIds,

--- a/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
+++ b/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
@@ -66,4 +66,17 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
         @Param("startDate") LocalDateTime startDate,
         @Param("endDate") LocalDateTime endDate,
         Pageable pageable);
+
+    @Query("""
+    SELECT d FROM Diary d
+    WHERE d.createdAt >= :twoWeeksAgo AND (
+        (d.userId IN :followingIds AND d.diaryVisibility = 'PUBLIC') OR
+        (d.userId IN :mutualBestFriendIds AND d.diaryVisibility = 'FOLLOWERS')
+    )
+    """)
+    Page<Diary> findFriendsDiaries(
+        @Param("followingIds") List<UUID> followingIds,
+        @Param("mutualBestFriendIds") List<UUID> mutualBestFriendIds,
+        @Param("twoWeeksAgo") LocalDateTime twoWeeksAgo,
+        Pageable pageable);
 }

--- a/src/main/java/doritos/doriroom/diary/service/DiaryService.java
+++ b/src/main/java/doritos/doriroom/diary/service/DiaryService.java
@@ -369,4 +369,58 @@ public class DiaryService {
             .toList();
     }
 
+    public Page<DiaryResponseDto> getFriendsDiaries(UUID currentUserId, Pageable pageable) {
+        LocalDateTime twoWeeksAgo = LocalDateTime.now().minusWeeks(2);
+
+        // 내가 팔로우하는 모든 친구 ID와 나를 단짝으로 설정한 친구 ID 목록을 조회
+        List<UUID> followingUserIds = followService.getFollowingIds(currentUserId);
+        List<UUID> mutualBestFriendIds = followService.getMutualBestFriendIds(currentUserId);
+
+        // 친구가 한 명도 없으면 빈 페이지 반환
+        if (followingUserIds.isEmpty() && mutualBestFriendIds.isEmpty()) {
+            return Page.empty(pageable);
+        }
+
+        // 단일 쿼리로 모든 조건에 맞는 일기를 DB에서 직접 페이징하여 조회
+        Page<Diary> friendsDiariesPage = diaryRepository.findFriendsDiaries(
+            followingUserIds,
+            mutualBestFriendIds,
+            twoWeeksAgo,
+            pageable
+        );
+
+        // 사용자, 이벤트 정보 배치 조회 및 DTO 변환
+        List<Diary> pagedDiaries = friendsDiariesPage.getContent();
+
+        List<UUID> userIds = pagedDiaries.stream()
+            .map(Diary::getUserId)
+            .distinct()
+            .toList();
+
+        List<UUID> eventIds = pagedDiaries.stream()
+            .map(Diary::getEventId)
+            .distinct()
+            .toList();
+
+        // ID 목록이 비어있으면 불필요한 DB 조회를 막음
+        Map<UUID, User> userMap = userIds.isEmpty() ? Collections.emptyMap() :
+            userRepository.findByUserIdIn(userIds).stream()
+                .collect(Collectors.toMap(User::getUserId, user -> user));
+
+        Map<UUID, Event> eventMap = eventIds.isEmpty() ? Collections.emptyMap() :
+            eventRepository.findByEventIdIn(eventIds).stream()
+                .collect(Collectors.toMap(Event::getEventId, event -> event));
+
+        // DTO 변환
+        List<DiaryResponseDto> diaryResponses = pagedDiaries.stream()
+            .map(diary -> {
+                User diaryUser = userMap.get(diary.getUserId());
+                Event event = eventMap.get(diary.getEventId());
+                return DiaryResponseDto.from(diary, 0L, diaryUser, event); // 0L 부분은 필요시 로직 추가
+            })
+            .toList();
+
+        return new PageImpl<>(diaryResponses, pageable, friendsDiariesPage.getTotalElements());
+    }
+
 }

--- a/src/main/java/doritos/doriroom/diary/service/DiaryService.java
+++ b/src/main/java/doritos/doriroom/diary/service/DiaryService.java
@@ -18,12 +18,14 @@ import doritos.doriroom.user.domain.User;
 import doritos.doriroom.user.exception.UserNotFoundException;
 import doritos.doriroom.user.repository.UserRepository;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -320,4 +322,51 @@ public class DiaryService {
 
         return new PageImpl<>(diaryResponseList, pageable, diaries.getTotalElements());
     }
+
+    //이달의 인기글 조회
+    public List<DiaryResponseDto> getPopularDiariesOfMonth() {
+        // 현재 월의 시작과 끝 날짜 계산
+        LocalDate today = LocalDate.now();
+        LocalDate startOfMonth = today.withDayOfMonth(1);
+        LocalDate endOfMonth = today.withDayOfMonth(today.lengthOfMonth());
+
+        LocalDateTime startDateTime = startOfMonth.atStartOfDay();
+        LocalDateTime endDateTime = endOfMonth.atTime(23, 59, 59);
+
+        // 인기글 조회 (좋아요 수 기준으로 정렬)
+        Pageable pageable = PageRequest.of(0, 10);
+        List<Diary> popularDiaries = diaryRepository.findPopularDiariesByMonth(
+            startDateTime, endDateTime, pageable);
+
+        if (popularDiaries.isEmpty()) {
+            return List.of();
+        }
+
+        // 사용자와 이벤트 정보 배치 조회
+        List<UUID> userIds = popularDiaries.stream()
+            .map(Diary::getUserId)
+            .distinct()
+            .toList();
+
+        List<UUID> eventIds = popularDiaries.stream()
+            .map(Diary::getEventId)
+            .distinct()
+            .toList();
+
+        Map<UUID, User> userMap = userRepository.findByUserIdIn(userIds).stream()
+            .collect(Collectors.toMap(User::getUserId, user -> user));
+
+        Map<UUID, Event> eventMap = eventRepository.findByEventIdIn(eventIds).stream()
+            .collect(Collectors.toMap(Event::getEventId, event -> event));
+
+        return popularDiaries.stream()
+            .map(diary -> {
+                User user = userMap.get(diary.getUserId());
+                Event event = eventMap.get(diary.getEventId());
+
+                return DiaryResponseDto.from(diary, 0L, user, event);
+            })
+            .toList();
+    }
+
 }

--- a/src/main/java/doritos/doriroom/diary/service/DiaryService.java
+++ b/src/main/java/doritos/doriroom/diary/service/DiaryService.java
@@ -11,6 +11,7 @@ import doritos.doriroom.event.domain.Event;
 import doritos.doriroom.event.dto.response.EventDiaryResponseDto;
 import doritos.doriroom.event.exception.EventNotFoundException;
 import doritos.doriroom.event.repository.EventRepository;
+import doritos.doriroom.follow.service.FollowService;
 import doritos.doriroom.s3.S3Uploader;
 import doritos.doriroom.user.domain.RoomVisibility;
 import doritos.doriroom.user.domain.User;
@@ -20,7 +21,6 @@ import java.time.LocalDate;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import doritos.doriroom.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -38,6 +38,7 @@ public class DiaryService {
     private final EventRepository eventRepository;
     private final S3Uploader s3Uploader;
     private final ChallengeService challengeService;
+    private final FollowService followService;
 
     private static final Long DIARY_WRITE_BASE_CREDIT = 3L;
     private static final Long PHOTO_ATTACHMENT_BONUS_CREDIT = 2L;
@@ -159,13 +160,25 @@ public class DiaryService {
 
         List<Diary> diaries;
         if (isOwner) {
-            // 자신의 일기: 모든 공개 범위의 일기를 조회
+            // 자신의 일기
             diaries = diaryRepository.findByUserIdAndVisitedAtBetweenOrderByVisitedAt(
                 targetUserId, startDate, endDate);
         } else {
-            // 다른 사용자의 일기: PUBLIC 일기만 조회
-            diaries = diaryRepository.findPublicByUserIdAndVisitedAtBetweenOrderByVisitedAt(
-                targetUserId, startDate, endDate);
+            // 다른 사용자의 일기
+            boolean isBestFriend = followService.isBestFriendByDiaryWriter(targetUserId, currentUserId);
+
+            if(isBestFriend) {
+                // 일기 작성자가 조회자를 베스트프렌드로 설정한 경우
+                diaries = diaryRepository.findPublicAndFollowersByUserIdAndVisitedAtBetweenOrderByVisitedAt(
+                    targetUserId,
+                    List.of(RoomVisibility.PUBLIC, RoomVisibility.FOLLOWERS),
+                    startDate,
+                    endDate);
+            } else {
+                // 단짝친구 아닌 경우
+                diaries = diaryRepository.findPublicByUserIdAndVisitedAtBetweenOrderByVisitedAt(
+                    targetUserId, startDate, endDate);
+            }
         }
 
         // 해당 월의 모든 날짜에 대해 초기화
@@ -307,6 +320,4 @@ public class DiaryService {
 
         return new PageImpl<>(diaryResponseList, pageable, diaries.getTotalElements());
     }
-
-
 }

--- a/src/main/java/doritos/doriroom/follow/repository/FollowRepository.java
+++ b/src/main/java/doritos/doriroom/follow/repository/FollowRepository.java
@@ -47,4 +47,22 @@ public interface FollowRepository extends JpaRepository<Follow, UUID> {
 
     List<Follow> findByFollowerAndFollowed_UserIdIn(User user, Set<UUID> targetUserIds); // 팔로우 정보 추출
 
+    /**
+     * 특정 사용자가 팔로우하는 모든 사용자의 ID를 조회
+     * Follow 엔티티 전체가 아닌 userId(UUID)만 조회
+     */
+    @Query("SELECT f.followed.userId FROM Follow f WHERE f.follower = :user")
+    List<UUID> findFollowingIdsByFollower(@Param("user") User user);
+
+    /**
+     * 특정 사용자를 '단짝'으로 설정한 맞팔로우 상태의 사용자 ID 목록을 조회
+     */
+    @Query("""
+        SELECT f1.followed.userId FROM Follow f1
+        WHERE f1.follower.userId = :currentUserId AND EXISTS (
+            SELECT 1 FROM Follow f2
+            WHERE f2.follower = f1.followed AND f2.followed = f1.follower AND f2.isBestFriend = true
+        )
+        """)
+    List<UUID> findMutualBestFriendIds(@Param("currentUserId") UUID currentUserId);
 }

--- a/src/main/java/doritos/doriroom/follow/service/FollowService.java
+++ b/src/main/java/doritos/doriroom/follow/service/FollowService.java
@@ -15,6 +15,7 @@ import doritos.doriroom.follow.repository.FollowRepository;
 import doritos.doriroom.user.domain.User;
 import doritos.doriroom.user.exception.UserNotFoundException;
 import doritos.doriroom.user.repository.UserRepository;
+import java.util.List;
 import java.util.Optional;
 import lombok.*;
 import org.springframework.data.domain.Page;
@@ -189,5 +190,17 @@ public class FollowService {
         }
     }
 
+    // 특정 사용자가 팔로우하는 모든 사용자의 ID 목록을 반환
+    public List<UUID> getFollowingIds(UUID currentUserId) {
+        User user = userRepository.findById(currentUserId)
+            .orElseThrow(UserNotFoundException::new);
+
+        return followRepository.findFollowingIdsByFollower(user);
+    }
+
+    // 특정 사용자를 '단짝'으로 설정한 맞팔로우 사용자 ID 목록을 반환
+    public List<UUID> getMutualBestFriendIds(UUID currentUserId) {
+        return followRepository.findMutualBestFriendIds(currentUserId);
+    }
 }
 

--- a/src/main/java/doritos/doriroom/follow/service/FollowService.java
+++ b/src/main/java/doritos/doriroom/follow/service/FollowService.java
@@ -1,14 +1,12 @@
 package doritos.doriroom.follow.service;
 
 import doritos.doriroom.challenge.domain.challenge.ChallengeType;
-import doritos.doriroom.challenge.repository.ChallengeRepository;
 import doritos.doriroom.challenge.service.ChallengeService;
 
 import doritos.doriroom.follow.domain.Follow;
 import doritos.doriroom.follow.dto.FollowFilterType;
 import doritos.doriroom.follow.dto.request.FollowRequestDto;
 import doritos.doriroom.follow.dto.request.SetBestFriendRequestDto;
-import doritos.doriroom.follow.dto.request.UserSearchRequestDto;
 import doritos.doriroom.follow.dto.response.*;
 import doritos.doriroom.follow.exception.CannotFollowSelfException;
 import doritos.doriroom.follow.exception.FollowAlreadyExistsException;
@@ -24,7 +22,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;

--- a/src/main/java/doritos/doriroom/follow/service/FollowService.java
+++ b/src/main/java/doritos/doriroom/follow/service/FollowService.java
@@ -17,6 +17,7 @@ import doritos.doriroom.follow.repository.FollowRepository;
 import doritos.doriroom.user.domain.User;
 import doritos.doriroom.user.exception.UserNotFoundException;
 import doritos.doriroom.user.repository.UserRepository;
+import java.util.Optional;
 import lombok.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -175,6 +176,20 @@ public class FollowService {
                     follow.getCreatedAt()
             );
         });
+    }
+
+    //일기 작성자가 조회자를 베스트프렌드로 설정했는지 확인
+    public boolean isBestFriendByDiaryWriter(UUID diaryWriterId, UUID viewerId) {
+        try {
+            // diaryWriterId가 viewerId를 베스트프렌드로 설정했는지 확인
+            User diaryWriter = userRepository.findById(diaryWriterId).orElseThrow(UserNotFoundException::new);
+            User viewer = userRepository.findById(viewerId).orElseThrow(UserNotFoundException::new);
+
+            Optional<Follow> follow = followRepository.findByFollowerAndFollowed(diaryWriter, viewer);
+            return follow.isPresent() && follow.get().isBestFriend();
+        } catch (Exception e) {
+            return false;
+        }
     }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

Closes #102 

## 📝작업 내용

1. 팔로잉 여부를 따져 일기 공개 여부 변경
- 친구의 월별 일기 조회
2. 이달의 인기글 구현
- 전체 일기를 좋아요 내림차순으로 정렬한 후 상위 10개 응답
3. 친구들 일기 모아보기 구현
- 내가 팔로우 하는 사람들의 public 일기 조회
- 내가 팔로우 하는 사람 && 나를 단짝으로 해준 사람인 경우 follow 일기 조회
- 작성일 기준 2주 내의 일기만 조회

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 인기 일기: 이번 달 좋아요 상위 일기 조회 엔드포인트 추가 (/api/diary/popular, 인증 필요, 최대 10개).
  * 친구 피드: 내가 팔로우한 사용자 및 상호 베스트프렌드의 최근 2주 일기를 페이지네이션으로 조회하는 엔드포인트 추가 (/api/diary/friends, 인증 필요, Pageable 지원).
  * 가시성 반영: 베스트프렌드 여부에 따라 공개/팔로워 전용 콘텐츠 접근 규칙 적용.
* **오류 처리**
  * 인증 사용자 확인 실패 시 적절한 오류 응답 반환.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->