### PR TITLE
feat(user): 회원탈퇴 soft delete 구현

### DIFF
--- a/src/main/java/doritos/doriroom/follow/repository/FollowRepository.java
+++ b/src/main/java/doritos/doriroom/follow/repository/FollowRepository.java
@@ -65,4 +65,6 @@ public interface FollowRepository extends JpaRepository<Follow, UUID> {
         )
         """)
     List<UUID> findMutualBestFriendIds(@Param("currentUserId") UUID currentUserId);
+
+    void deleteByFollowerOrFollowed(User follower, User followed);
 }

--- a/src/main/java/doritos/doriroom/user/controller/UserController.java
+++ b/src/main/java/doritos/doriroom/user/controller/UserController.java
@@ -2,8 +2,8 @@ package doritos.doriroom.user.controller;
 
 
 import doritos.doriroom.follow.dto.request.UserSearchRequestDto;
+import doritos.doriroom.user.dto.request.UserWithdrawalRequestDto;
 import doritos.doriroom.user.dto.response.UserSearchResultDto;
-import doritos.doriroom.follow.service.FollowService;
 import doritos.doriroom.global.dto.ApiResponse;
 import doritos.doriroom.user.domain.User;
 import doritos.doriroom.user.dto.request.ChangePasswordRequestDto;
@@ -31,14 +31,13 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-@Tag(name = "User", description = "")
+@Tag(name = "User", description = "유저 관련 API")
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;
     private final RoomLikeService roomLikeService;
-    private final FollowService followService;
 
         @GetMapping("/check-username")
         @Operation(summary = "아이디 중복 확인")
@@ -104,6 +103,14 @@ public class UserController {
         public ApiResponse<Void> changePassword(@AuthenticationPrincipal User user,
                                                 @Valid @RequestBody ChangePasswordRequestDto request) {
             userService.changePassword(user, request);
+            return ApiResponse.ok();
+        }
+
+        @PostMapping("/me/withdraw")
+        @Operation(summary = "회원 탈퇴 요청", description = "유저 정보 및 팔로우 정보 삭제")
+        public ApiResponse<Void> withdraw(@AuthenticationPrincipal User user,
+                                          @Valid @RequestBody UserWithdrawalRequestDto request){
+            userService.withdraw(user, request);
             return ApiResponse.ok();
         }
 

--- a/src/main/java/doritos/doriroom/user/domain/User.java
+++ b/src/main/java/doritos/doriroom/user/domain/User.java
@@ -46,7 +46,7 @@ public class User {
     private int viewCount = 0;
 
     // 회원 탈퇴 필드
-    @Builder.Default
+    @Builder.Default @Column(nullable = false)
     private boolean isWithdraw  = false; // 탈퇴 상태
     private LocalDateTime withdrawDate; // 탈퇴 시각
 

--- a/src/main/java/doritos/doriroom/user/domain/User.java
+++ b/src/main/java/doritos/doriroom/user/domain/User.java
@@ -3,6 +3,7 @@ import doritos.doriroom.user.exception.NotEnoughCreditException;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
@@ -43,6 +44,11 @@ public class User {
     @Builder.Default
     @Column(nullable = false)
     private int viewCount = 0;
+
+    // 회원 탈퇴 필드
+    @Builder.Default
+    private boolean isWithdraw  = false; // 탈퇴 상태
+    private LocalDateTime withdrawDate; // 탈퇴 시각
 
     // 포인트 관련 메서드 추가
     public void addCredit(Long creditCount) {

--- a/src/main/java/doritos/doriroom/user/dto/request/UserWithdrawalRequestDto.java
+++ b/src/main/java/doritos/doriroom/user/dto/request/UserWithdrawalRequestDto.java
@@ -1,0 +1,8 @@
+package doritos.doriroom.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UserWithdrawalRequestDto(
+        @NotBlank(message = "현재 비밀번호를 입력해주세요.")
+        String password
+) {}

--- a/src/main/java/doritos/doriroom/user/service/UserService.java
+++ b/src/main/java/doritos/doriroom/user/service/UserService.java
@@ -5,6 +5,7 @@ import doritos.doriroom.challenge.domain.challenge.ChallengeType;
 import doritos.doriroom.challenge.service.ChallengeService;
 import doritos.doriroom.follow.domain.Follow;
 import doritos.doriroom.follow.dto.request.UserSearchRequestDto;
+import doritos.doriroom.user.dto.request.UserWithdrawalRequestDto;
 import doritos.doriroom.user.dto.response.UserSearchResultDto;
 import doritos.doriroom.follow.repository.FollowRepository;
 import doritos.doriroom.item.dto.response.EquippedItemResponse;
@@ -22,6 +23,8 @@ import doritos.doriroom.user.exception.DuplicateException;
 import doritos.doriroom.user.exception.SelfRoomInfoNotAllowedException;
 import doritos.doriroom.user.exception.UserNotFoundException;
 import doritos.doriroom.user.repository.UserRepository;
+
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -130,6 +133,30 @@ public class UserService {
         }
 
         foundUser.setPassword(encoder.encode(request.newPassword())); // 새 비밀번호를 암호화하여 저장
+    }
+
+    @Transactional
+    public void withdraw(User user, UserWithdrawalRequestDto request){
+        if (!encoder.matches(request.password(), user.getPassword())){
+            throw new InvalidPasswordException("비밀번호가 일치하지 않습니다.");
+        }
+
+        // 개인정보 비식별화
+        String key = "WITHDRAWN_";
+        String withdrawnUserId = (key + user.getUserId().toString()+ "_" + System.currentTimeMillis());
+        user.setUsername(withdrawnUserId);
+        user.setEmail(withdrawnUserId + "@dori.com");
+        user.setNickname(key + user.getNickname()+ "_" + System.currentTimeMillis());
+        user.setPassword(encoder.encode(UUID.randomUUID().toString())); // 비밀번호를 아무도 모르는 값으로 변경
+        user.setProfileImageUrl(null);
+
+        // 상태 및 탈퇴일시 변경
+        user.setWithdraw(true);
+        user.setWithdrawDate(LocalDateTime.now());
+
+        // 팔로우 관계 연관 데이터 정리
+        followRepository.deleteByFollowerOrFollowed(user, user);
+
     }
 
     //내 방 정보

--- a/src/main/java/doritos/doriroom/user/service/UserService.java
+++ b/src/main/java/doritos/doriroom/user/service/UserService.java
@@ -137,25 +137,38 @@ public class UserService {
 
     @Transactional
     public void withdraw(User user, UserWithdrawalRequestDto request){
-        if (!encoder.matches(request.password(), user.getPassword())){
+        User foundUser = userRepository.findByUserId(user.getUserId())
+                .orElseThrow(UserNotFoundException::new);
+
+        if (foundUser.isWithdraw()) {
+            return;
+        }
+
+        if (!encoder.matches(request.password(), foundUser.getPassword())){
             throw new InvalidPasswordException("비밀번호가 일치하지 않습니다.");
+        }
+
+        // 기존 프로필 이미지가 있으면 S3에서 삭제 후 URL 제거
+        if (StringUtils.hasText(foundUser.getProfileImageUrl())) {
+            s3Uploader.deleteFile(foundUser.getProfileImageUrl());
+            foundUser.setProfileImageUrl(null);
         }
 
         // 개인정보 비식별화
         String key = "WITHDRAWN_";
-        String withdrawnUserId = (key + user.getUserId().toString()+ "_" + System.currentTimeMillis());
-        user.setUsername(withdrawnUserId);
-        user.setEmail(withdrawnUserId + "@dori.com");
-        user.setNickname(key + user.getNickname()+ "_" + System.currentTimeMillis());
-        user.setPassword(encoder.encode(UUID.randomUUID().toString())); // 비밀번호를 아무도 모르는 값으로 변경
-        user.setProfileImageUrl(null);
+        String withdrawnUserId = (key + foundUser.getUserId().toString()+ "_" + System.currentTimeMillis());
+        foundUser.setUsername(withdrawnUserId);
+        foundUser.setEmail(withdrawnUserId + "@dori.com");
+        foundUser.setNickname(key + foundUser.getNickname()+ "_" + System.currentTimeMillis());
+        foundUser.setPassword(encoder.encode(UUID.randomUUID().toString())); // 비밀번호를 아무도 모르는 값으로 변경
+        foundUser.setProfileImageUrl(null);
 
         // 상태 및 탈퇴일시 변경
-        user.setWithdraw(true);
-        user.setWithdrawDate(LocalDateTime.now());
+        foundUser.setWithdraw(true);
+        foundUser.setWithdrawDate(LocalDateTime.now());
 
         // 팔로우 관계 연관 데이터 정리
-        followRepository.deleteByFollowerOrFollowed(user, user);
+        followRepository.deleteByFollowerOrFollowed(foundUser, foundUser);
 
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#63 

## 📝작업 내용

회원 탈퇴 API 구현.
유저 정보 비식별화 처리 및 팔로우 팔로잉 정보 삭제

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 계정 탈퇴 기능 추가: 비밀번호 확인 후 탈퇴 처리(아이디/이메일/닉네임 비식별화, 비밀번호 초기화, 프로필 이미지 제거, 탈퇴 상태 및 시각 기록).
  - 탈퇴 시 팔로우 관계 일괄 해제 자동 적용.
  - 사용자 API에 "내 계정 탈퇴" 엔드포인트 추가: 내 정보에서 안전하게 탈퇴 요청 제출 가능.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->