### PR TITLE
feat(polygon): 폴리곤 정보 응답에 추가

### DIFF
--- a/src/main/java/doritos/doriroom/challenge/dto/response/ChallengeResponseDto.java
+++ b/src/main/java/doritos/doriroom/challenge/dto/response/ChallengeResponseDto.java
@@ -29,6 +29,7 @@ public record ChallengeResponseDto(
 
         int targetCount,
         UUID eventId, // nullable
+        String polygon,
         List<ChallengeRewardDto> rewards, // nullable
 
         int currentProgress,
@@ -47,6 +48,7 @@ public record ChallengeResponseDto(
                 .challengeType(challenge.getChallengeType())
                 .targetCount(challenge.getTargetCount())
                 .eventId(challenge.getEvent() != null ? challenge.getEvent().getEventId() : null)
+                .polygon(challenge.getEvent() != null ? challenge.getEvent().getPolygon() : null)
                 .rewards(challenge.getRewards() == null
                         ? List.of()
                         : challenge.getRewards().stream()


### PR DESCRIPTION
## #️⃣연관된 이슈

#115 

## 📝작업 내용
 
도전 과제 조회 시 응답 필드에 이벤트id와 함께 이벤트 폴리곤 정보 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 챌린지 조회 API 응답에 polygon 문자열 필드가 추가되었습니다. 이벤트가 연결된 경우 값이 포함되며, 없으면 누락될 수 있습니다.
  * 기존 필드와 동작에는 변경이 없습니다.
  * 응답 스키마가 확장되었으므로 클라이언트는 신규 필드 존재 여부를 확인하도록 파싱 로직을 점검하세요.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->