### PR TITLE
축제별 일기 작성 여부 확인

### DIFF
--- a/src/main/java/doritos/doriroom/diary/controller/DiaryController.java
+++ b/src/main/java/doritos/doriroom/diary/controller/DiaryController.java
@@ -164,4 +164,14 @@ public class DiaryController {
         Page<DiaryResponseDto> response = diaryService.getFriendsDiaries(user.getUserId(), pageable);
         return ApiResponse.ok(response);
     }
+
+    @Operation(summary = "축제별 일기 작성 여부 확인", description = "사용자가 특정 축제에 대해 일기를 작성했는지 여부를 확인합니다.")
+    @GetMapping("/written/{eventId}")
+    public ApiResponse<Boolean> hasUserWrittenDiaryForEvent(
+        @AuthenticationPrincipal User user,
+        @PathVariable @Schema(description = "축제 ID", example = "550e8400-e29b-41d4-a716-446655440002")
+        UUID eventId) {
+        boolean hasWritten = diaryService.getUserWrittenDiaryForEvent(user.getUserId(), eventId);
+        return ApiResponse.ok(hasWritten);
+    }
 }

--- a/src/main/java/doritos/doriroom/diary/repository/DiaryLikeRepository.java
+++ b/src/main/java/doritos/doriroom/diary/repository/DiaryLikeRepository.java
@@ -4,10 +4,17 @@ import doritos.doriroom.diary.domain.DiaryLike;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface DiaryLikeRepository extends JpaRepository<DiaryLike, UUID> {
     @Query("SELECT dl FROM DiaryLike dl WHERE dl.user.userId = :userId AND dl.diary.diaryId = :diaryId")
     Optional<DiaryLike> findByUserIdAndDiaryId(@Param("userId") UUID userId, @Param("diaryId") UUID diaryId);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM DiaryLike dl WHERE dl.diary.diaryId = :diaryId")
+    void deleteByDiaryId(@Param("diaryId") UUID diaryId);
 }

--- a/src/main/java/doritos/doriroom/diary/service/DiaryService.java
+++ b/src/main/java/doritos/doriroom/diary/service/DiaryService.java
@@ -427,4 +427,11 @@ public class DiaryService {
         return new PageImpl<>(diaryResponses, pageable, friendsDiariesPage.getTotalElements());
     }
 
+    public boolean getUserWrittenDiaryForEvent(UUID userId, UUID eventId) {
+        eventRepository.findById(eventId).orElseThrow(EventNotFoundException::new);
+        userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+
+        return diaryRepository.existsByUserIdAndEventId(userId, eventId);
+    }
+
 }

--- a/src/main/java/doritos/doriroom/diary/service/DiaryService.java
+++ b/src/main/java/doritos/doriroom/diary/service/DiaryService.java
@@ -6,6 +6,7 @@ import doritos.doriroom.diary.domain.Diary;
 import doritos.doriroom.diary.dto.request.*;
 import doritos.doriroom.diary.dto.response.*;
 import doritos.doriroom.diary.exception.*;
+import doritos.doriroom.diary.repository.DiaryLikeRepository;
 import doritos.doriroom.diary.repository.DiaryRepository;
 import doritos.doriroom.event.domain.Event;
 import doritos.doriroom.event.dto.response.EventDiaryResponseDto;
@@ -36,6 +37,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class DiaryService {
     private final DiaryRepository diaryRepository;
+    private final DiaryLikeRepository diaryLikeRepository;
     private final UserRepository userRepository;
     private final EventRepository eventRepository;
     private final S3Uploader s3Uploader;
@@ -121,6 +123,9 @@ public class DiaryService {
             throw new DiaryAuthorizationException();
         }
 
+        // 일기 삭제 전에 관련된 좋아요들을 먼저 삭제
+        diaryLikeRepository.deleteByDiaryId(diaryId);
+
         if (diary.getImageUrls() != null && !diary.getImageUrls().isEmpty()) {
             s3Uploader.deleteFiles(diary.getImageUrls());
         }
@@ -131,7 +136,6 @@ public class DiaryService {
             event.decrementDiaryCount();
             eventRepository.save(event);
         }
-
 
         diaryRepository.delete(diary);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#118 

## 📝작업 내용
축제별 일기 작성 여부 확인 API 구현
일기 삭제 시, 좋아요 여부와 상관없이 삭제 가능하도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 특정 이벤트에 대해 사용자가 일기를 작성했는지 여부를 확인할 수 있습니다. 관련 화면에서 상태가 명확히 안내됩니다.
- 버그 수정
  - 일기 삭제 시 연결된 좋아요가 함께 정리되어 좋아요 수와 표시가 정확하게 반영됩니다. 안정성과 데이터 일관성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->