### PR TITLE
Feat/120 api fix

### DIFF
--- a/src/main/java/doritos/doriroom/diary/controller/DiaryController.java
+++ b/src/main/java/doritos/doriroom/diary/controller/DiaryController.java
@@ -120,17 +120,18 @@ public class DiaryController {
     }
 
     @Operation(summary = "일별 일기 목록 조회", description = "특정 날짜에 작성된 일기 목록을 조회합니다.")
-    @GetMapping("/daily")
+    @GetMapping("/{userId}/daily")
     public ApiResponse<DailyDiaryListResponseDto> getDailyDiaries(
         @AuthenticationPrincipal User user,
-        @RequestParam
-        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        @PathVariable @Schema(description = "조회할 유저 ID", example = "43d1a5a2-58dc-4786-8dba-27c62cae1943")
+        UUID userId,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
         @Schema(
             description = "조회할 날짜 (YYYY-MM-DD 형식)",
             example = "2025-08-10"
         )
         LocalDate date) {
-        DailyDiaryListResponseDto response = diaryService.getDailyDiaries(user.getUserId(), date);
+        DailyDiaryListResponseDto response = diaryService.getDailyDiaries(user.getUserId(), userId, date);
         return ApiResponse.ok(response);
     }
 

--- a/src/main/java/doritos/doriroom/diary/controller/DiaryController.java
+++ b/src/main/java/doritos/doriroom/diary/controller/DiaryController.java
@@ -102,8 +102,9 @@ public class DiaryController {
     @Operation(summary = "일기 상세 조회", description = "일기 상세 정보를 조회합니다.")
     @GetMapping("/{diaryId}")
     public ApiResponse<DiaryDetailResponseDto> getDiaryDetail(
+        @AuthenticationPrincipal User user,
         @PathVariable UUID diaryId) {
-        DiaryDetailResponseDto response = diaryService.getDiaryDetail(diaryId);
+        DiaryDetailResponseDto response = diaryService.getDiaryDetail(user.getUserId(), diaryId);
         return ApiResponse.ok(response);
     }
 

--- a/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
+++ b/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
@@ -20,10 +20,10 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
 
     List<Diary> findByUserIdAndVisitedAtOrderByCreatedAtDesc(UUID userId, LocalDate visitedAt);
 
-    @Query("SELECT d FROM Diary d WHERE d.eventId = :eventId AND d.diaryVisibility = 'PUBLIC' ORDER BY d.visitedAt DESC, d.diaryId DESC")
+    @Query("SELECT d FROM Diary d WHERE d.eventId = :eventId AND d.diaryVisibility = 'PUBLIC' ORDER BY d.createdAt DESC")
     Page<Diary> findPublicDiariesByEventId(@Param("eventId") UUID eventId, Pageable pageable);
 
-    @Query("SELECT d FROM Diary d WHERE d.userId = :userId AND d.diaryVisibility = 'PUBLIC' ORDER BY d.visitedAt DESC, d.diaryId DESC")
+    @Query("SELECT d FROM Diary d WHERE d.userId = :userId AND d.diaryVisibility = 'PUBLIC' ORDER BY d.visitedAt DESC, d.createdAt DESC")
     Page<Diary> findPublicByUserIdOrderByVisitedAtDesc(@Param("userId") UUID userId, Pageable pageable);
 
     @Query("""
@@ -31,7 +31,7 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
         WHERE d.userId = :userId
         AND d.diaryVisibility = 'PUBLIC'
         AND d.visitedAt BETWEEN :startDate AND :endDate
-        ORDER BY d.visitedAt DESC, d.diaryId DESC
+        ORDER BY d.visitedAt
         """)
     List<Diary> findPublicByUserIdAndVisitedAtBetweenOrderByVisitedAt(
         @Param("userId") UUID userId,
@@ -47,7 +47,7 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
         WHERE d.userId = :userId
         AND d.diaryVisibility IN (:visibilities)
         AND d.visitedAt BETWEEN :startDate AND :endDate
-        ORDER BY d.visitedAt DESC, d.diaryId DESC
+        ORDER BY d.visitedAt
         """)
     List<Diary> findPublicAndFollowersByUserIdAndVisitedAtBetweenOrderByVisitedAt(
         @Param("userId") UUID userId,
@@ -58,9 +58,9 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
     @Query("""
         SELECT d FROM Diary d
         WHERE d.diaryVisibility = 'PUBLIC'
-        AND d.visitedAt >= :startDate
-        AND d.visitedAt <= :endDate
-        ORDER BY (d.likes * 2) DESC, d.visitedAt DESC, d.diaryId DESC
+        AND d.createdAt >= :startDate
+        AND d.createdAt <= :endDate
+        ORDER BY (d.likes * 2) DESC, d.createdAt DESC
         """)
     List<Diary> findPopularDiariesByMonth(
         @Param("startDate") LocalDateTime startDate,
@@ -69,11 +69,11 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
 
     @Query("""
     SELECT d FROM Diary d
-    WHERE d.visitedAt >= :twoWeeksAgo AND (
+    WHERE d.createdAt >= :twoWeeksAgo AND (
         (d.userId IN :followingIds AND d.diaryVisibility = 'PUBLIC') OR
         (d.userId IN :mutualBestFriendIds AND d.diaryVisibility = 'FOLLOWERS')
     )
-    ORDER BY d.visitedAt DESC, d.diaryId DESC
+    ORDER BY d.createdAt DESC, d.diaryId DESC
     """)
     Page<Diary> findFriendsDiaries(
         @Param("followingIds") List<UUID> followingIds,
@@ -86,7 +86,7 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
         WHERE d.userId = :userId
         AND d.diaryVisibility = 'PUBLIC'
         AND d.visitedAt = :visitedAt
-        ORDER BY d.visitedAt DESC, d.diaryId DESC
+        ORDER BY d.createdAt DESC
         """)
     List<Diary> findPublicByUserIdAndVisitedAtOrderByCreatedAtDesc(
         @Param("userId") UUID userId,
@@ -97,7 +97,7 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
         WHERE d.userId = :userId
         AND d.diaryVisibility IN (:visibilities)
         AND d.visitedAt = :visitedAt
-        ORDER BY d.visitedAt DESC, d.diaryId DESC
+        ORDER BY d.createdAt DESC
         """)
     List<Diary> findPublicAndFollowersByUserIdAndVisitedAtOrderByCreatedAtDesc(
         @Param("userId") UUID userId,

--- a/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
+++ b/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
@@ -80,4 +80,27 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
         @Param("mutualBestFriendIds") List<UUID> mutualBestFriendIds,
         @Param("twoWeeksAgo") LocalDateTime twoWeeksAgo,
         Pageable pageable);
+
+    @Query("""
+        SELECT d FROM Diary d
+        WHERE d.userId = :userId
+        AND d.diaryVisibility = 'PUBLIC'
+        AND d.visitedAt = :visitedAt
+        ORDER BY d.createdAt DESC
+        """)
+    List<Diary> findPublicByUserIdAndVisitedAtOrderByCreatedAtDesc(
+        @Param("userId") UUID userId,
+        @Param("visitedAt") LocalDate visitedAt);
+
+    @Query("""
+        SELECT d FROM Diary d
+        WHERE d.userId = :userId
+        AND d.diaryVisibility IN (:visibilities)
+        AND d.visitedAt = :visitedAt
+        ORDER BY d.createdAt DESC
+        """)
+    List<Diary> findPublicAndFollowersByUserIdAndVisitedAtOrderByCreatedAtDesc(
+        @Param("userId") UUID userId,
+        @Param("visibilities") List<RoomVisibility> visibilities,
+        @Param("visitedAt") LocalDate visitedAt);
 }

--- a/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
+++ b/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
@@ -20,10 +20,10 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
 
     List<Diary> findByUserIdAndVisitedAtOrderByCreatedAtDesc(UUID userId, LocalDate visitedAt);
 
-    @Query("SELECT d FROM Diary d WHERE d.eventId = :eventId AND d.diaryVisibility = 'PUBLIC' ORDER BY d.createdAt DESC")
+    @Query("SELECT d FROM Diary d WHERE d.eventId = :eventId AND d.diaryVisibility = 'PUBLIC' ORDER BY d.visitedAt DESC, d.diaryId DESC")
     Page<Diary> findPublicDiariesByEventId(@Param("eventId") UUID eventId, Pageable pageable);
 
-    @Query("SELECT d FROM Diary d WHERE d.userId = :userId AND d.diaryVisibility = 'PUBLIC' ORDER BY d.visitedAt DESC, d.createdAt DESC")
+    @Query("SELECT d FROM Diary d WHERE d.userId = :userId AND d.diaryVisibility = 'PUBLIC' ORDER BY d.visitedAt DESC, d.diaryId DESC")
     Page<Diary> findPublicByUserIdOrderByVisitedAtDesc(@Param("userId") UUID userId, Pageable pageable);
 
     @Query("""
@@ -31,7 +31,7 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
         WHERE d.userId = :userId
         AND d.diaryVisibility = 'PUBLIC'
         AND d.visitedAt BETWEEN :startDate AND :endDate
-        ORDER BY d.visitedAt
+        ORDER BY d.visitedAt DESC, d.diaryId DESC
         """)
     List<Diary> findPublicByUserIdAndVisitedAtBetweenOrderByVisitedAt(
         @Param("userId") UUID userId,
@@ -47,7 +47,7 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
         WHERE d.userId = :userId
         AND d.diaryVisibility IN (:visibilities)
         AND d.visitedAt BETWEEN :startDate AND :endDate
-        ORDER BY d.visitedAt
+        ORDER BY d.visitedAt DESC, d.diaryId DESC
         """)
     List<Diary> findPublicAndFollowersByUserIdAndVisitedAtBetweenOrderByVisitedAt(
         @Param("userId") UUID userId,
@@ -58,9 +58,9 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
     @Query("""
         SELECT d FROM Diary d
         WHERE d.diaryVisibility = 'PUBLIC'
-        AND d.createdAt >= :startDate
-        AND d.createdAt <= :endDate
-        ORDER BY (d.likes * 2) DESC, d.createdAt DESC
+        AND d.visitedAt >= :startDate
+        AND d.visitedAt <= :endDate
+        ORDER BY (d.likes * 2) DESC, d.visitedAt DESC, d.diaryId DESC
         """)
     List<Diary> findPopularDiariesByMonth(
         @Param("startDate") LocalDateTime startDate,
@@ -69,11 +69,11 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
 
     @Query("""
     SELECT d FROM Diary d
-    WHERE d.createdAt >= :twoWeeksAgo AND (
+    WHERE d.visitedAt >= :twoWeeksAgo AND (
         (d.userId IN :followingIds AND d.diaryVisibility = 'PUBLIC') OR
         (d.userId IN :mutualBestFriendIds AND d.diaryVisibility = 'FOLLOWERS')
     )
-    ORDER BY d.createdAt DESC, d.diaryId DESC
+    ORDER BY d.visitedAt DESC, d.diaryId DESC
     """)
     Page<Diary> findFriendsDiaries(
         @Param("followingIds") List<UUID> followingIds,
@@ -86,7 +86,7 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
         WHERE d.userId = :userId
         AND d.diaryVisibility = 'PUBLIC'
         AND d.visitedAt = :visitedAt
-        ORDER BY d.createdAt DESC
+        ORDER BY d.visitedAt DESC, d.diaryId DESC
         """)
     List<Diary> findPublicByUserIdAndVisitedAtOrderByCreatedAtDesc(
         @Param("userId") UUID userId,
@@ -97,7 +97,7 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
         WHERE d.userId = :userId
         AND d.diaryVisibility IN (:visibilities)
         AND d.visitedAt = :visitedAt
-        ORDER BY d.createdAt DESC
+        ORDER BY d.visitedAt DESC, d.diaryId DESC
         """)
     List<Diary> findPublicAndFollowersByUserIdAndVisitedAtOrderByCreatedAtDesc(
         @Param("userId") UUID userId,

--- a/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
+++ b/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
@@ -88,7 +88,7 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
         AND d.visitedAt = :visitedAt
         ORDER BY d.visitedAt DESC, d.diaryId DESC
         """)
-    List<Diary> findPublicByUserIdAndVisitedAtOrderByCreatedAtDesc(
+    List<Diary> findPublicByUserIdAndVisitedAtOrderByVisitedAtDesc(
         @Param("userId") UUID userId,
         @Param("visitedAt") LocalDate visitedAt);
 
@@ -99,7 +99,7 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
         AND d.visitedAt = :visitedAt
         ORDER BY d.visitedAt DESC, d.diaryId DESC
         """)
-    List<Diary> findPublicAndFollowersByUserIdAndVisitedAtOrderByCreatedAtDesc(
+    List<Diary> findPublicAndFollowersByUserIdAndVisitedAtOrderByVisitedAtDesc(
         @Param("userId") UUID userId,
         @Param("visibilities") List<RoomVisibility> visibilities,
         @Param("visitedAt") LocalDate visitedAt);

--- a/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
+++ b/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
@@ -88,7 +88,7 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
         AND d.visitedAt = :visitedAt
         ORDER BY d.visitedAt DESC, d.diaryId DESC
         """)
-    List<Diary> findPublicByUserIdAndVisitedAtOrderByVisitedAtDesc(
+    List<Diary> findPublicByUserIdAndVisitedAtOrderByCreatedAtDesc(
         @Param("userId") UUID userId,
         @Param("visitedAt") LocalDate visitedAt);
 
@@ -99,7 +99,7 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
         AND d.visitedAt = :visitedAt
         ORDER BY d.visitedAt DESC, d.diaryId DESC
         """)
-    List<Diary> findPublicAndFollowersByUserIdAndVisitedAtOrderByVisitedAtDesc(
+    List<Diary> findPublicAndFollowersByUserIdAndVisitedAtOrderByCreatedAtDesc(
         @Param("userId") UUID userId,
         @Param("visibilities") List<RoomVisibility> visibilities,
         @Param("visitedAt") LocalDate visitedAt);

--- a/src/main/java/doritos/doriroom/diary/service/DiaryService.java
+++ b/src/main/java/doritos/doriroom/diary/service/DiaryService.java
@@ -147,12 +147,6 @@ public class DiaryService {
         Diary diary = diaryRepository.findById(diaryId)
             .orElseThrow(DiaryNotFoundException::new);
 
-        User user = userRepository.findById(diary.getUserId())
-            .orElseThrow(UserNotFoundException::new);
-
-        Event event = eventRepository.findById(diary.getEventId())
-            .orElseThrow(EventNotFoundException::new);
-
         // 권한 검증
         boolean isOwnDiary = currentUserId.equals(diary.getUserId());
 
@@ -169,6 +163,12 @@ public class DiaryService {
                 throw new DiaryAuthorizationException();
             }
         }
+
+        User user = userRepository.findById(diary.getUserId())
+            .orElseThrow(UserNotFoundException::new);
+
+        Event event = eventRepository.findById(diary.getEventId())
+            .orElseThrow(EventNotFoundException::new);
 
         return DiaryDetailResponseDto.from(diary, user, event);
     }
@@ -227,35 +227,6 @@ public class DiaryService {
 
         return DiaryWritingStatusResponseDto.from(targetUserId, year, month, dailyStatusMap);
     }
-
-    //일별 작성한 일기 목록 조회
-//    public DailyDiaryListResponseDto getDailyDiaries(UUID userId, LocalDate date) {
-//        List<Diary> diaries = diaryRepository.findByUserIdAndVisitedAtOrderByCreatedAtDesc(userId, date);
-//
-//        if (diaries.isEmpty()) {
-//            return DailyDiaryListResponseDto.from(userId, date, List.of());
-//        }
-//
-//        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
-//
-//        List<UUID> eventIds = diaries.stream()
-//            .map(Diary::getEventId)
-//            .distinct()
-//            .toList();
-//
-//        Map<UUID, Event> eventMap = eventRepository.findByEventIdIn(eventIds).stream()
-//            .collect(Collectors.toMap(Event::getEventId, event -> event));
-//
-//        List<DiaryResponseDto> diaryList = diaries.stream()
-//            .map(diary -> {
-//                Event event = eventMap.get(diary.getEventId());
-//
-//                return DiaryResponseDto.from(diary, 0L, user, event);
-//            })
-//            .toList();
-//
-//        return DailyDiaryListResponseDto.from(userId, date, diaryList);
-//    }
 
     public DailyDiaryListResponseDto getDailyDiaries(UUID currentUserId, UUID targetUserId, LocalDate date) {
         userRepository.findById(currentUserId).orElseThrow(UserNotFoundException::new);

--- a/src/main/java/doritos/doriroom/diary/service/DiaryService.java
+++ b/src/main/java/doritos/doriroom/diary/service/DiaryService.java
@@ -246,13 +246,13 @@ public class DiaryService {
 
             if (isBestFriend) {
                 // 일기 작성자가 조회자를 단짝으로 설정한 경우
-                diaries = diaryRepository.findPublicAndFollowersByUserIdAndVisitedAtOrderByCreatedAtDesc(
+                diaries = diaryRepository.findPublicAndFollowersByUserIdAndVisitedAtOrderByVisitedAtDesc(
                     targetUserId,
                     List.of(RoomVisibility.PUBLIC, RoomVisibility.FOLLOWERS),
                     date);
             } else {
                 // 단짝친구 아닌 경우 - 공개 일기만 조회
-                diaries = diaryRepository.findPublicByUserIdAndVisitedAtOrderByCreatedAtDesc(targetUserId, date);
+                diaries = diaryRepository.findPublicByUserIdAndVisitedAtOrderByVisitedAtDesc(targetUserId, date);
             }
         }
 

--- a/src/main/java/doritos/doriroom/diary/service/DiaryService.java
+++ b/src/main/java/doritos/doriroom/diary/service/DiaryService.java
@@ -246,13 +246,13 @@ public class DiaryService {
 
             if (isBestFriend) {
                 // 일기 작성자가 조회자를 단짝으로 설정한 경우
-                diaries = diaryRepository.findPublicAndFollowersByUserIdAndVisitedAtOrderByVisitedAtDesc(
+                diaries = diaryRepository.findPublicAndFollowersByUserIdAndVisitedAtOrderByCreatedAtDesc(
                     targetUserId,
                     List.of(RoomVisibility.PUBLIC, RoomVisibility.FOLLOWERS),
                     date);
             } else {
                 // 단짝친구 아닌 경우 - 공개 일기만 조회
-                diaries = diaryRepository.findPublicByUserIdAndVisitedAtOrderByVisitedAtDesc(targetUserId, date);
+                diaries = diaryRepository.findPublicByUserIdAndVisitedAtOrderByCreatedAtDesc(targetUserId, date);
             }
         }
 

--- a/src/main/java/doritos/doriroom/diary/service/DiaryService.java
+++ b/src/main/java/doritos/doriroom/diary/service/DiaryService.java
@@ -143,7 +143,7 @@ public class DiaryService {
         challengeService.updateChallengeProgress(user, ChallengeType.WRITE_DIARY, -1);
     }
 
-    public DiaryDetailResponseDto getDiaryDetail(UUID diaryId) {
+    public DiaryDetailResponseDto getDiaryDetail(UUID currentUserId,UUID diaryId) {
         Diary diary = diaryRepository.findById(diaryId)
             .orElseThrow(DiaryNotFoundException::new);
 
@@ -152,6 +152,23 @@ public class DiaryService {
 
         Event event = eventRepository.findById(diary.getEventId())
             .orElseThrow(EventNotFoundException::new);
+
+        // 권한 검증
+        boolean isOwnDiary = currentUserId.equals(diary.getUserId());
+
+        if (!isOwnDiary) {
+            boolean isBestFriend = followService.isBestFriendByDiaryWriter(diary.getUserId(), currentUserId);
+
+            if (!isBestFriend && diary.getDiaryVisibility() != RoomVisibility.PUBLIC) {
+                // 단짝이 아니고 공개 일기가 아닌 경우 접근 불가
+                throw new DiaryAuthorizationException();
+            }
+
+            if (isBestFriend && diary.getDiaryVisibility() == RoomVisibility.PRIVATE) {
+                // 단짝이라도 비공개 일기는 접근 불가
+                throw new DiaryAuthorizationException();
+            }
+        }
 
         return DiaryDetailResponseDto.from(diary, user, event);
     }

--- a/src/main/java/doritos/doriroom/diary/service/DiaryService.java
+++ b/src/main/java/doritos/doriroom/diary/service/DiaryService.java
@@ -212,14 +212,65 @@ public class DiaryService {
     }
 
     //일별 작성한 일기 목록 조회
-    public DailyDiaryListResponseDto getDailyDiaries(UUID userId, LocalDate date) {
-        List<Diary> diaries = diaryRepository.findByUserIdAndVisitedAtOrderByCreatedAtDesc(userId, date);
+//    public DailyDiaryListResponseDto getDailyDiaries(UUID userId, LocalDate date) {
+//        List<Diary> diaries = diaryRepository.findByUserIdAndVisitedAtOrderByCreatedAtDesc(userId, date);
+//
+//        if (diaries.isEmpty()) {
+//            return DailyDiaryListResponseDto.from(userId, date, List.of());
+//        }
+//
+//        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+//
+//        List<UUID> eventIds = diaries.stream()
+//            .map(Diary::getEventId)
+//            .distinct()
+//            .toList();
+//
+//        Map<UUID, Event> eventMap = eventRepository.findByEventIdIn(eventIds).stream()
+//            .collect(Collectors.toMap(Event::getEventId, event -> event));
+//
+//        List<DiaryResponseDto> diaryList = diaries.stream()
+//            .map(diary -> {
+//                Event event = eventMap.get(diary.getEventId());
+//
+//                return DiaryResponseDto.from(diary, 0L, user, event);
+//            })
+//            .toList();
+//
+//        return DailyDiaryListResponseDto.from(userId, date, diaryList);
+//    }
 
-        if (diaries.isEmpty()) {
-            return DailyDiaryListResponseDto.from(userId, date, List.of());
+    public DailyDiaryListResponseDto getDailyDiaries(UUID currentUserId, UUID targetUserId, LocalDate date) {
+        userRepository.findById(currentUserId).orElseThrow(UserNotFoundException::new);
+        User targetUser = userRepository.findById(targetUserId).orElseThrow(UserNotFoundException::new);
+
+        List<Diary> diaries;
+
+        // 자신의 일기인지 확인
+        boolean isOwnDiary = currentUserId.equals(targetUserId);
+
+        if (isOwnDiary) {
+            // 자신의 일기 - 모든 일기 조회
+            diaries = diaryRepository.findByUserIdAndVisitedAtOrderByCreatedAtDesc(targetUserId, date);
+        } else {
+            // 다른 사용자의 일기 - 단짝 여부에 따라 조회 범위 결정
+            boolean isBestFriend = followService.isBestFriendByDiaryWriter(targetUserId, currentUserId);
+
+            if (isBestFriend) {
+                // 일기 작성자가 조회자를 단짝으로 설정한 경우
+                diaries = diaryRepository.findPublicAndFollowersByUserIdAndVisitedAtOrderByCreatedAtDesc(
+                    targetUserId,
+                    List.of(RoomVisibility.PUBLIC, RoomVisibility.FOLLOWERS),
+                    date);
+            } else {
+                // 단짝친구 아닌 경우 - 공개 일기만 조회
+                diaries = diaryRepository.findPublicByUserIdAndVisitedAtOrderByCreatedAtDesc(targetUserId, date);
+            }
         }
 
-        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+        if (diaries.isEmpty()) {
+            return DailyDiaryListResponseDto.from(targetUserId, date, List.of());
+        }
 
         List<UUID> eventIds = diaries.stream()
             .map(Diary::getEventId)
@@ -232,12 +283,11 @@ public class DiaryService {
         List<DiaryResponseDto> diaryList = diaries.stream()
             .map(diary -> {
                 Event event = eventMap.get(diary.getEventId());
-
-                return DiaryResponseDto.from(diary, 0L, user, event);
+                return DiaryResponseDto.from(diary, 0L, targetUser, event);
             })
             .toList();
 
-        return DailyDiaryListResponseDto.from(userId, date, diaryList);
+        return DailyDiaryListResponseDto.from(targetUserId, date, diaryList);
     }
 
     //축제별 일기 조회

--- a/src/main/java/doritos/doriroom/diary/service/DiaryService.java
+++ b/src/main/java/doritos/doriroom/diary/service/DiaryService.java
@@ -147,6 +147,12 @@ public class DiaryService {
         Diary diary = diaryRepository.findById(diaryId)
             .orElseThrow(DiaryNotFoundException::new);
 
+        User user = userRepository.findById(diary.getUserId())
+            .orElseThrow(UserNotFoundException::new);
+
+        Event event = eventRepository.findById(diary.getEventId())
+            .orElseThrow(EventNotFoundException::new);
+
         // 권한 검증
         boolean isOwnDiary = currentUserId.equals(diary.getUserId());
 
@@ -163,12 +169,6 @@ public class DiaryService {
                 throw new DiaryAuthorizationException();
             }
         }
-
-        User user = userRepository.findById(diary.getUserId())
-            .orElseThrow(UserNotFoundException::new);
-
-        Event event = eventRepository.findById(diary.getEventId())
-            .orElseThrow(EventNotFoundException::new);
 
         return DiaryDetailResponseDto.from(diary, user, event);
     }
@@ -227,6 +227,35 @@ public class DiaryService {
 
         return DiaryWritingStatusResponseDto.from(targetUserId, year, month, dailyStatusMap);
     }
+
+    //일별 작성한 일기 목록 조회
+//    public DailyDiaryListResponseDto getDailyDiaries(UUID userId, LocalDate date) {
+//        List<Diary> diaries = diaryRepository.findByUserIdAndVisitedAtOrderByCreatedAtDesc(userId, date);
+//
+//        if (diaries.isEmpty()) {
+//            return DailyDiaryListResponseDto.from(userId, date, List.of());
+//        }
+//
+//        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+//
+//        List<UUID> eventIds = diaries.stream()
+//            .map(Diary::getEventId)
+//            .distinct()
+//            .toList();
+//
+//        Map<UUID, Event> eventMap = eventRepository.findByEventIdIn(eventIds).stream()
+//            .collect(Collectors.toMap(Event::getEventId, event -> event));
+//
+//        List<DiaryResponseDto> diaryList = diaries.stream()
+//            .map(diary -> {
+//                Event event = eventMap.get(diary.getEventId());
+//
+//                return DiaryResponseDto.from(diary, 0L, user, event);
+//            })
+//            .toList();
+//
+//        return DailyDiaryListResponseDto.from(userId, date, diaryList);
+//    }
 
     public DailyDiaryListResponseDto getDailyDiaries(UUID currentUserId, UUID targetUserId, LocalDate date) {
         userRepository.findById(currentUserId).orElseThrow(UserNotFoundException::new);


### PR DESCRIPTION
## #️⃣연관된 이슈
Closes #120

## 📝작업 내용

일별 일기 조회 시 일기 작성자와 로그인 한 사용자 간의 단짝 여부별로 일별 일기 조회.
일기 상세 조회시에도 단짝 여부별 조회 권한 부여

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 일기 상세 및 일별 목록 조회가 요청자와 대상자 관계(본인·베스트친구·공개)에 따라 결과를 제한하고 표시합니다.
  - 일별 조회 엔드포인트에 대상 사용자 식별자를 포함해 특정 사용자의 하루 일지를 조회할 수 있습니다.
  - 일별 응답에서 작성자는 대상 사용자로 표시됩니다.

- **Bug Fixes**
  - 방문일(visitedAt) 기준 필터링 및 생성일(createdAt) 기준 정렬로 조회 일관성 개선.
  - 권한 검사 강화로 비공개 일기 노출 차단.

- **Documentation**
  - 대상 사용자 파라미터와 경로에 대한 API 문서 보완.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->