### PR TITLE
hotfix: 유저 방 정보 api 경로 수정

### DIFF
--- a/src/main/java/doritos/doriroom/user/controller/UserController.java
+++ b/src/main/java/doritos/doriroom/user/controller/UserController.java
@@ -125,7 +125,8 @@ public class UserController {
         @Operation(summary = "다른 유저 방 정보 조회", description = "특정 유저의 방 정보 조회. 방문 시 조회수 증가")
         public ApiResponse<OtherUserRoomResponseDto> getOtherUserRoomInfo(
             @AuthenticationPrincipal User user,
-            @RequestParam @Valid UUID userId
+            @Parameter(description = "다른 유저 ID", example = "76ec4646-164b-41d8-8787-a66fd05af448", required = true)
+            @PathVariable("userId") UUID userId
         ){
             return ApiResponse.ok(userService.getOtherUserRoomInfo(user.getUserId(), userId));
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 다른 유저 방 정보 조회 API가 쿼리 파라미터 대신 경로 변수로 userId를 받도록 변경되었습니다. 이제 요청 형식은 GET /room/{userId} 입니다. 기존 ?userId=... 호출을 사용하는 클라이언트는 경로 변수 방식으로 업데이트가 필요합니다.

- **Documentation**
  - OpenAPI 스펙에 userId 경로 변수 설명과 예제가 추가되어 API 문서 가독성과 정확성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->