### PR TITLE
Feat/124 diary

### DIFF
--- a/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
+++ b/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
@@ -40,7 +40,7 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
 
     boolean existsByUserIdAndEventId(UUID userId, UUID eventId);
 
-    Page<Diary> findByUserIdOrderByVisitedAtDesc(UUID userId, Pageable pageable);
+    Page<Diary> findByUserIdOrderByCreatedAtDesc(UUID userId, Pageable pageable);
 
     @Query("""
         SELECT d FROM Diary d

--- a/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
+++ b/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
@@ -60,7 +60,7 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
         WHERE d.diaryVisibility = 'PUBLIC'
         AND d.createdAt >= :startDate
         AND d.createdAt <= :endDate
-        ORDER BY (d.likes * 2) DESC, d.createdAt DESC
+        ORDER BY d.likes DESC, d.createdAt DESC, d.diaryId DESC
         limit 5
         """)
     List<Diary> findPopularDiariesByMonth(

--- a/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
+++ b/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
@@ -61,7 +61,6 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
         AND d.createdAt >= :startDate
         AND d.createdAt <= :endDate
         ORDER BY d.likes DESC, d.createdAt DESC, d.diaryId DESC
-        limit 5
         """)
     List<Diary> findPopularDiariesByMonth(
         @Param("startDate") LocalDateTime startDate,

--- a/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
+++ b/src/main/java/doritos/doriroom/diary/repository/DiaryRepository.java
@@ -61,6 +61,7 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
         AND d.createdAt >= :startDate
         AND d.createdAt <= :endDate
         ORDER BY (d.likes * 2) DESC, d.createdAt DESC
+        limit 5
         """)
     List<Diary> findPopularDiariesByMonth(
         @Param("startDate") LocalDateTime startDate,

--- a/src/main/java/doritos/doriroom/diary/service/DiaryService.java
+++ b/src/main/java/doritos/doriroom/diary/service/DiaryService.java
@@ -405,7 +405,7 @@ public class DiaryService {
         LocalDateTime endDateTime = endOfMonth.atTime(23, 59, 59);
 
         // 인기글 조회 (좋아요 수 기준으로 정렬)
-        Pageable pageable = PageRequest.of(0, 10);
+        Pageable pageable = PageRequest.of(0, 5);
         List<Diary> popularDiaries = diaryRepository.findPopularDiariesByMonth(
             startDateTime, endDateTime, pageable);
 

--- a/src/main/java/doritos/doriroom/diary/service/DiaryService.java
+++ b/src/main/java/doritos/doriroom/diary/service/DiaryService.java
@@ -344,7 +344,7 @@ public class DiaryService {
         boolean isOwnDiary = currentUserId.equals(targetUserId);
 
         Page<Diary> diaries = isOwnDiary ?
-            diaryRepository.findByUserIdOrderByVisitedAtDesc(targetUserId, pageable) :
+            diaryRepository.findByUserIdOrderByCreatedAtDesc(targetUserId, pageable) :
             diaryRepository.findPublicByUserIdOrderByVisitedAtDesc(targetUserId, pageable);
 
         return createDiaryResponsePage(diaries, targetUser, pageable);


### PR DESCRIPTION
## #️⃣연관된 이슈

Closes #124 

## 📝작업 내용

1. 일기 조회를 createdAt 순으로 변경
- 인기 일기, 친구 일기, 내 일기 모아보기에 적용

2. 인기있는 일기 5개만 조회


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 내 일기 목록이 ‘최근 작성일(createdAt)’ 기준으로 최신순 정렬됩니다.
  - 월간 인기 일기 정렬이 좋아요 우선 → 작성일 → 일기 ID 순으로 안정화되어 동률 처리 방식이 개선됩니다.
  - 월간 인기 일기 결과가 상위 5개로 제한되어 간결하게 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->