### PR TITLE
Hotfix/memory

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -68,4 +68,5 @@ jobs:
               -v $(pwd)/app.yml:/app/config/application.yml \
               -e SPRING_CONFIG_LOCATION=file:/app/config/ \
               --network host \
+              --cpus=0.95 \
               ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_IMAGE_NAME }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,5 +34,5 @@ RUN apt-get update && \
 # 빌드 스테이지(builder)에서 생성된 JAR 파일만 안전하게 복사해옵니다.
 COPY --from=builder /workspace/build/libs/*.jar app.jar
 
-# 컨테이너의 안정성을 위해 JVM 힙 메모리 옵션을 명시합니다.
-ENTRYPOINT ["java", "-Xms512m", "-Xmx512m", "-jar", "/app.jar"]
+# 컨테이너의 안정성을 위해 JVM 힙 메모리 옵션과 CPU 사용제한 명시
+ENTRYPOINT ["java", "-Xms512m", "-Xmx512m", "-XX:ActiveProcessorCount=1", "-XX:+UseG1GC", "-jar", "/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,9 @@ dependencies {
 
     // aws
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	// monitoring
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 

--- a/src/main/java/doritos/doriroom/event/service/EventService.java
+++ b/src/main/java/doritos/doriroom/event/service/EventService.java
@@ -15,6 +15,8 @@ import doritos.doriroom.event.repository.EventRepository;
 import java.time.LocalDate;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -114,7 +116,7 @@ public class EventService {
                         event.getContentId());
 
                     // 두 작업이 모두 끝날 때까지 기다림
-                    CompletableFuture.allOf(introFuture, infoFuture).join();
+                    CompletableFuture.allOf(introFuture, infoFuture).get(30, TimeUnit.SECONDS);
                     processedCount += 2;
 
                     // 결과 가져오기
@@ -131,6 +133,10 @@ public class EventService {
                         event.updateDetailInfoFrom(detailInfoList);
                         currentStatus = EventDetailStatus.SUCCESS;
                     }
+                } catch (TimeoutException e) {
+                    log.error("API 호출 타임아웃: contentId={}", event.getContentId(), e);
+                    currentStatus = EventDetailStatus.FAILED;
+                    processedCount += 2;
                 } catch (Exception e) {
                     log.error("축제 상세정보 업데이트 실패. contentId: {}, error: {}", event.getContentId(),
                         e.getMessage());

--- a/src/main/java/doritos/doriroom/event/service/EventService.java
+++ b/src/main/java/doritos/doriroom/event/service/EventService.java
@@ -211,12 +211,4 @@ public class EventService {
 
         return EventDetailResponseDto.from(event);
     }
-
-    //도별 축제 정보 반환
-    public Page<EventResponseDto> getEventsByAreaGroup(AreaGroup areaGroup, Pageable pageable) {
-        List<Integer> areaCodes = areaGroup.getAreaCodes();
-
-        Page<Event> events = eventRepository.findByAreaCodesIn(areaCodes, pageable);
-        return events.map(EventResponseDto::from);
-    }
 }

--- a/src/main/java/doritos/doriroom/event/service/EventService.java
+++ b/src/main/java/doritos/doriroom/event/service/EventService.java
@@ -95,36 +95,36 @@ public class EventService {
     public void updateEventDetails() {
         List<Event> events = eventRepository.findByEventDetailStatusOrderByStartDateDesc(EventDetailStatus.PENDING);
         int dailyLimit = 900;
-        int processedCount = 0;
+        int processedEvents = 0; // 이벤트 수로 집계
 
         log.info("축제 상세정보 업데이트 시작");
 
         for (Event event : events) {
             EventDetailStatus currentStatus;
-            if (processedCount >= dailyLimit) {
-                log.info("오늘의 업데이트 한도({}개)에 도달했습니다. 남은 이벤트: {}개", dailyLimit, events.size() - processedCount);
+            if (processedEvents >= dailyLimit) {
+                log.info("오늘의 업데이트 한도({}개)에 도달했습니다. 남은 이벤트: {}개", dailyLimit, events.size() - processedEvents);
                 break;
             }
 
             if(event.getEventDetailStatus() == EventDetailStatus.PENDING) {
+                CompletableFuture<TourApiDetailIntroDto> introFuture = null;
+                CompletableFuture<List<TourApiDetailInfoDto>> infoFuture = null;
+                
                 try {
                     // 두 API를 비동기 호출
-                    CompletableFuture<TourApiDetailIntroDto> introFuture = tourApiService.fetchEventDetailIntro(
-                        event.getContentId());
-                    CompletableFuture<List<TourApiDetailInfoDto>> infoFuture = tourApiService.fetchEventDetailInfo(
-                        event.getContentId());
+                    introFuture = tourApiService.fetchEventDetailIntro(event.getContentId());
+                    infoFuture = tourApiService.fetchEventDetailInfo(event.getContentId());
 
-                    // 두 작업이 모두 끝날 때까지 기다림
+                    // 타임아웃 설정 (30초)
                     CompletableFuture.allOf(introFuture, infoFuture).get(30, TimeUnit.SECONDS);
-                    processedCount += 2;
+                    processedEvents++; // 이벤트 단위로 카운트
 
                     // 결과 가져오기
                     TourApiDetailIntroDto detailIntroDto = introFuture.get();
                     List<TourApiDetailInfoDto> detailInfoList = infoFuture.get();
 
                     // API에서 삭제된 경우
-                    if (detailIntroDto == null && (detailInfoList == null
-                        || detailInfoList.isEmpty())) {
+                    if (detailIntroDto == null && (detailInfoList == null || detailInfoList.isEmpty())) {
                         currentStatus = EventDetailStatus.DELETED_FROM_API;
                         log.warn("API에서 삭제된 이벤트 발견. contentId: {}", event.getContentId());
                     } else {
@@ -135,12 +135,20 @@ public class EventService {
                 } catch (TimeoutException e) {
                     log.error("API 호출 타임아웃: contentId={}", event.getContentId(), e);
                     currentStatus = EventDetailStatus.FAILED;
-                    processedCount += 2;
+                    
+                    // 진행 중인 future 취소
+                    if (introFuture != null) {
+                        introFuture.cancel(true);
+                    }
+                    if (infoFuture != null) {
+                        infoFuture.cancel(true);
+                    }
+                    processedEvents++;
+                    continue;
                 } catch (Exception e) {
-                    log.error("축제 상세정보 업데이트 실패. contentId: {}, error: {}", event.getContentId(),
-                        e.getMessage());
+                    log.error("축제 상세정보 업데이트 실패. contentId: {}, error: {}", event.getContentId(), e.getMessage());
                     currentStatus = EventDetailStatus.FAILED;
-                    processedCount += 2;
+                    processedEvents++;
                 }
 
                 //결정된 상태를 엔티티에 반영하고 저장
@@ -179,13 +187,19 @@ public class EventService {
         //DB에 상세정보가 없으면 tourAPI 호출
         if(event.getEventDetailStatus() == EventDetailStatus.PENDING){
             EventDetailStatus currentStatus;
+            CompletableFuture<TourApiDetailIntroDto> introFuture = null;
+            CompletableFuture<List<TourApiDetailInfoDto>> infoFuture = null;
+            
             try{
                 // 두 API를 비동기 호출
-                CompletableFuture<TourApiDetailIntroDto> introFuture = tourApiService.fetchEventDetailIntro(event.getContentId());
-                CompletableFuture<List<TourApiDetailInfoDto>> infoFuture = tourApiService.fetchEventDetailInfo(event.getContentId());
+                introFuture = tourApiService.fetchEventDetailIntro(event.getContentId());
+                infoFuture = tourApiService.fetchEventDetailInfo(event.getContentId());
 
-                // 두 작업이 모두 끝날 때까지 기다림
-                CompletableFuture.allOf(introFuture, infoFuture).join();
+                // 타임아웃 설정 (30초)
+                CompletableFuture.allOf(
+                    introFuture.orTimeout(30, TimeUnit.SECONDS),
+                    infoFuture.orTimeout(30, TimeUnit.SECONDS)
+                ).join();
 
                 // 결과 가져오기
                 TourApiDetailIntroDto detailIntroDto = introFuture.get();
@@ -201,9 +215,10 @@ public class EventService {
                     event.updateDetailInfoFrom(detailInfoList);
                 }
             } catch (Exception e){
-                currentStatus = EventDetailStatus.FAILED;
                 log.error("축제 상세 정보 업데이트 실패: eventId={}, error={}", eventId, e.getMessage());
+                currentStatus = EventDetailStatus.FAILED;
             }
+            
             event.changeEventDetailStatus(currentStatus);
             eventRepository.save(event);
         }

--- a/src/main/java/doritos/doriroom/event/service/EventService.java
+++ b/src/main/java/doritos/doriroom/event/service/EventService.java
@@ -134,8 +134,7 @@ public class EventService {
                     }
                 } catch (TimeoutException e) {
                     log.error("API 호출 타임아웃: contentId={}", event.getContentId(), e);
-                    currentStatus = EventDetailStatus.FAILED;
-                    
+
                     // 진행 중인 future 취소
                     if (introFuture != null) {
                         introFuture.cancel(true);
@@ -187,13 +186,13 @@ public class EventService {
         //DB에 상세정보가 없으면 tourAPI 호출
         if(event.getEventDetailStatus() == EventDetailStatus.PENDING){
             EventDetailStatus currentStatus;
-            CompletableFuture<TourApiDetailIntroDto> introFuture = null;
-            CompletableFuture<List<TourApiDetailInfoDto>> infoFuture = null;
-            
+//            CompletableFuture<TourApiDetailIntroDto> introFuture = null;
+//            CompletableFuture<List<TourApiDetailInfoDto>> infoFuture = null;
+
             try{
                 // 두 API를 비동기 호출
-                introFuture = tourApiService.fetchEventDetailIntro(event.getContentId());
-                infoFuture = tourApiService.fetchEventDetailInfo(event.getContentId());
+                CompletableFuture<TourApiDetailIntroDto> introFuture = tourApiService.fetchEventDetailIntro(event.getContentId());
+                CompletableFuture<List<TourApiDetailInfoDto>> infoFuture = tourApiService.fetchEventDetailInfo(event.getContentId());
 
                 // 타임아웃 설정 (30초)
                 CompletableFuture.allOf(

--- a/src/main/java/doritos/doriroom/event/service/EventService.java
+++ b/src/main/java/doritos/doriroom/event/service/EventService.java
@@ -6,7 +6,6 @@ import doritos.doriroom.event.dto.request.EventItemFilterRequestDto;
 import doritos.doriroom.event.dto.response.EventDetailResponseDto;
 import doritos.doriroom.event.dto.response.EventResponseDto;
 import doritos.doriroom.event.exception.EventNotFoundException;
-import doritos.doriroom.tourApi.domain.AreaGroup;
 import doritos.doriroom.tourApi.dto.response.TourApiDetailInfoDto;
 import doritos.doriroom.tourApi.dto.response.TourApiDetailIntroDto;
 import doritos.doriroom.tourApi.dto.response.TourApiItemDto;

--- a/src/main/java/doritos/doriroom/event/service/EventService.java
+++ b/src/main/java/doritos/doriroom/event/service/EventService.java
@@ -94,7 +94,7 @@ public class EventService {
     @Transactional
     public void updateEventDetails() {
         List<Event> events = eventRepository.findByEventDetailStatusOrderByStartDateDesc(EventDetailStatus.PENDING);
-        int dailyLimit = 900;
+        int dailyLimit = 450;
         int processedEvents = 0; // 이벤트 수로 집계
 
         log.info("축제 상세정보 업데이트 시작");
@@ -186,8 +186,6 @@ public class EventService {
         //DB에 상세정보가 없으면 tourAPI 호출
         if(event.getEventDetailStatus() == EventDetailStatus.PENDING){
             EventDetailStatus currentStatus;
-//            CompletableFuture<TourApiDetailIntroDto> introFuture = null;
-//            CompletableFuture<List<TourApiDetailInfoDto>> infoFuture = null;
 
             try{
                 // 두 API를 비동기 호출

--- a/src/main/java/doritos/doriroom/global/config/WebClientConfig.java
+++ b/src/main/java/doritos/doriroom/global/config/WebClientConfig.java
@@ -18,7 +18,7 @@ public class WebClientConfig {
         return WebClient.builder()
             .uriBuilderFactory(uriBuilderFactory)
             .codecs(configurer ->
-                configurer.defaultCodecs().maxInMemorySize(5 * 1024 * 1024) // 5MB
+                configurer.defaultCodecs().maxInMemorySize(2 * 1024 * 1024) // 2MB
             )
             .baseUrl("https://apis.data.go.kr")
             .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/doritos/doriroom/global/log/LoggerFilter.java
+++ b/src/main/java/doritos/doriroom/global/log/LoggerFilter.java
@@ -32,23 +32,35 @@ public class LoggerFilter extends OncePerRequestFilter {
         ContentCachingResponseWrapper wrappedResponse = new ContentCachingResponseWrapper(response);
         wrappedResponse.setCharacterEncoding(StandardCharsets.UTF_8.name());
 
-        filterChain.doFilter(request, wrappedResponse);
+        try {
+            filterChain.doFilter(request, wrappedResponse);
+        } finally {
+            // 메모리 정리
+            try {
+                long end = System.currentTimeMillis();
+                long elapsed = end - start;
 
-        long end = System.currentTimeMillis();
-        long elapsed = end - start;
+                ResponseInfo responseInfo = getResponseInfo(wrappedResponse);
 
-        ResponseInfo responseInfo = getResponseInfo(wrappedResponse);
+                log.info("{} {} {} {}ms {}{}",
+                    request.getMethod(),
+                    request.getRequestURI(),
+                    getIp(request),
+                    elapsed,
+                    responseInfo.statusCode(),
+                    responseInfo.error() == null ? "" : " - %s".formatted(responseInfo.error())
+                );
 
-        log.info("{} {} {} {}ms {}{}",
-            request.getMethod(),
-            request.getRequestURI(),
-            getIp(request),
-            elapsed,
-            responseInfo.statusCode(),
-            responseInfo.error() == null ? "" : " - %s".formatted(responseInfo.error())
-        );
-
-        wrappedResponse.copyBodyToResponse(); // 응답을 원본에 복사
+                wrappedResponse.copyBodyToResponse();
+            } finally {
+                // ContentCachingResponseWrapper 정리
+                try {
+                    wrappedResponse.reset();
+                } catch (Exception e) {
+                    log.warn("Response wrapper reset failed", e);
+                }
+            }
+        }
     }
 
     private ResponseInfo getResponseInfo(ContentCachingResponseWrapper response) {

--- a/src/main/java/doritos/doriroom/global/log/LoggerFilter.java
+++ b/src/main/java/doritos/doriroom/global/log/LoggerFilter.java
@@ -55,7 +55,9 @@ public class LoggerFilter extends OncePerRequestFilter {
             } finally {
                 // ContentCachingResponseWrapper 정리
                 try {
-                    wrappedResponse.reset();
+                    if (!response.isCommitted()) {
+                        wrappedResponse.copyBodyToResponse();
+                    }
                 } catch (Exception e) {
                     log.warn("Response wrapper reset failed", e);
                 }

--- a/src/main/java/doritos/doriroom/global/security/SecurityConfig.java
+++ b/src/main/java/doritos/doriroom/global/security/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(authorize -> authorize
                 .requestMatchers(SWAGGER_ENDPOINTS).permitAll()
                 .requestMatchers("/api/auth/**", "/api/users/check-username", "/api/users/check-nickname").permitAll()
+                .requestMatchers("/actuator/**").permitAll()
                 .requestMatchers("/api/**").authenticated()
             ).addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 


### PR DESCRIPTION
## 📝작업 내용

메모리 누수나는 부분 리팩토링


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - 이벤트 상세 조회 동시 호출에 30초 타임아웃과 호출 취소/타임아웃 처리 및 예외별 상태 저장을 추가해 무한 대기와 오류 상태를 방지했습니다.
  - 필터의 후처리·로깅을 finally로 보장해 요청/응답 로그와 리소스 정리를 안정화했습니다.
- Refactor
  - 지역 그룹 기반 이벤트 조회 API 제거, 이벤트 처리 카운트/상태 판정 및 저장 로직 개선.
- Chores
  - WebClient 메모리 한도 5MB→2MB, AWS 의존성 제거 및 Actuator 추가(모니터링 엔드포인트 허용).
  - Docker/배포: 컨테이너 CPU 제한(0.95) 추가 및 실행 시 ActiveProcessorCount=1·G1GC 설정 적용.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->