### PR TITLE
feat: 단짝 여부 확인용 API 추가

### DIFF
--- a/src/main/java/doritos/doriroom/follow/controller/FollowController.java
+++ b/src/main/java/doritos/doriroom/follow/controller/FollowController.java
@@ -14,7 +14,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import java.util.List;
 import java.util.UUID;
 
 
@@ -52,6 +51,13 @@ public class FollowController {
     public ApiResponse<FollowStatusResponseDto> getFollowStatus(@AuthenticationPrincipal User user,
                                                                 @PathVariable UUID targetUserId) {
         return ApiResponse.ok(followService.getFollowStatus(user, targetUserId));
+    }
+
+    @Operation(summary = "단짝친구 여부 확인", description = "특정 유저와 단짝친구인지 여부만 확인")
+    @GetMapping("/status/best/{targetUserId}")
+    public ApiResponse<Boolean> checkBestFriendStatus(@AuthenticationPrincipal User user,
+        @PathVariable UUID targetUserId) {
+        return ApiResponse.ok(followService.isBestFriend(user, targetUserId));
     }
 
 

--- a/src/main/java/doritos/doriroom/follow/service/FollowService.java
+++ b/src/main/java/doritos/doriroom/follow/service/FollowService.java
@@ -202,5 +202,22 @@ public class FollowService {
     public List<UUID> getMutualBestFriendIds(UUID currentUserId) {
         return followRepository.findMutualBestFriendIds(currentUserId);
     }
+
+    public boolean isBestFriend(User user, UUID targetUserId) {
+        try {
+            // 자신과의 단짝친구 관계는 불가능
+            if (user.getUserId().equals(targetUserId)) {
+                return false;
+            }
+
+            User targetUser = userRepository.findById(targetUserId)
+                .orElseThrow(UserNotFoundException::new);
+
+            Optional<Follow> follow = followRepository.findByFollowerAndFollowed(user, targetUser);
+            return follow.isPresent() && follow.get().isBestFriend();
+        } catch (Exception e) {
+            return false;
+        }
+    }
 }
 


### PR DESCRIPTION
단짝친구 확인용 API 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 단짝친구 상태 확인 API가 추가되었습니다. 로그인한 사용자와 지정한 대상 사용자 간 관계를 불리언으로 반환합니다. 표준 응답 형식으로 제공되며, 기존 기능과의 호환성에 영향이 없습니다.
- 문서
  - OpenAPI 문서에 해당 엔드포인트의 요약과 설명이 추가되어, 최신 스펙에서 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->