### PR TITLE
feat: 축제 검색 시 정렬 기능 추가

### DIFF
--- a/src/main/java/doritos/doriroom/event/domain/EventSortType.java
+++ b/src/main/java/doritos/doriroom/event/domain/EventSortType.java
@@ -1,0 +1,7 @@
+package doritos.doriroom.event.domain;
+
+public enum EventSortType {
+    RECOMMENDED, // 추천순
+    LATEST,      // 최신순
+    POPULAR      // 좋아요순
+}

--- a/src/main/java/doritos/doriroom/event/dto/request/EventItemFilterRequestDto.java
+++ b/src/main/java/doritos/doriroom/event/dto/request/EventItemFilterRequestDto.java
@@ -1,5 +1,6 @@
 package doritos.doriroom.event.dto.request;
 
+import doritos.doriroom.event.domain.EventSortType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.util.List;
@@ -21,6 +22,9 @@ public record EventItemFilterRequestDto(
     LocalDate endDate,
 
     @Schema(description = "검색 키워드", example = "축제")
-    String keyword
+    String keyword,
+
+    @Schema(description = "정렬 타입 (RECOMMENDED: 추천순, LATEST: 최신순, POPULAR: 좋아요순)", example = "RECOMMENDED")
+    EventSortType sortType
     ) {
 }

--- a/src/main/java/doritos/doriroom/event/repository/EventRepositoryImpl.java
+++ b/src/main/java/doritos/doriroom/event/repository/EventRepositoryImpl.java
@@ -47,7 +47,7 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
             query.orderBy(getOrderSpecifier(filter.sortType(), event));
         } else {
             // 기본 정렬: 최신순
-            query.orderBy(event.startDate.desc());
+            query.orderBy(event.startDate.desc(), event.eventId.desc());
         }
 
         List<Event> results = query
@@ -167,10 +167,10 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
                     .add(event.favoriteCount)
                     .intValue();
 
-                yield new OrderSpecifier<?>[]{recommendationScore.desc(), event.startDate.desc()};
+                yield new OrderSpecifier<?>[]{recommendationScore.desc(), event.startDate.desc(), event.eventId.desc()};
             }
             case LATEST -> new OrderSpecifier<?>[]{event.startDate.desc()};
-            case POPULAR -> new OrderSpecifier<?>[]{event.favoriteCount.desc(), event.startDate.desc()};
+            case POPULAR -> new OrderSpecifier<?>[]{event.favoriteCount.desc(), event.startDate.desc(), event.eventId.desc()};
         };
     }
 }

--- a/src/main/java/doritos/doriroom/event/repository/EventRepositoryImpl.java
+++ b/src/main/java/doritos/doriroom/event/repository/EventRepositoryImpl.java
@@ -1,12 +1,15 @@
 package doritos.doriroom.event.repository;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import doritos.doriroom.diary.domain.QDiary;
 import doritos.doriroom.event.domain.Event;
 import doritos.doriroom.event.domain.EventDetailStatus;
+import doritos.doriroom.event.domain.EventSortType;
 import doritos.doriroom.event.domain.QEvent;
 import doritos.doriroom.event.domain.QEventFavorite;
 import doritos.doriroom.event.dto.request.EventItemFilterRequestDto;
@@ -38,6 +41,14 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
                 eqDateRange(filter.startDate(), filter.endDate(), event),
                 eqKeyword(filter.keyword(), event)
             );
+
+        // 정렬 적용
+        if (filter.sortType() != null) {
+            query.orderBy(getOrderSpecifier(filter.sortType(), event));
+        } else {
+            // 기본 정렬: 최신순
+            query.orderBy(event.startDate.desc());
+        }
 
         List<Event> results = query
             .offset(pageable.getOffset())
@@ -146,5 +157,20 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
 
     private BooleanExpression isSuccessStatus(QEvent event) {
         return event.eventDetailStatus.eq(EventDetailStatus.SUCCESS);
+    }
+
+    private OrderSpecifier<?>[] getOrderSpecifier(EventSortType sortType, QEvent event) {
+        return switch (sortType) {
+            case RECOMMENDED -> {
+                // 추천순: (일기개수*2 + 좋아요수) 내림차순, 시작일 내림차순
+                NumberExpression<Integer> recommendationScore = event.diaryCount.multiply(2)
+                    .add(event.favoriteCount)
+                    .intValue();
+
+                yield new OrderSpecifier<?>[]{recommendationScore.desc(), event.startDate.desc()};
+            }
+            case LATEST -> new OrderSpecifier<?>[]{event.startDate.desc()};
+            case POPULAR -> new OrderSpecifier<?>[]{event.favoriteCount.desc(), event.startDate.desc()};
+        };
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#141 

## 📝작업 내용

축제 검색 시 정렬 기능을 추가했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 새 기능
  * 이벤트 목록에 정렬 옵션 추가: 추천순, 최신순, 좋아요순.
  * 검색/필터 결과에서 정렬 방식 선택 가능.
  * 정렬 미선택 시 기본값은 최신순.
  * 추천순은 참여도와 선호도를 반영해 더 관련성 높은 이벤트를 상단에 표시.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->