### PR TITLE
Feature/137 item cache

### DIFF
--- a/src/main/java/doritos/doriroom/challenge/service/ChallengeService.java
+++ b/src/main/java/doritos/doriroom/challenge/service/ChallengeService.java
@@ -1,5 +1,6 @@
 package doritos.doriroom.challenge.service;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import doritos.doriroom.atlas.service.AtlasService;
 import doritos.doriroom.challenge.domain.challenge.Challenge;
 import doritos.doriroom.challenge.domain.challenge.ChallengeGroup;
@@ -12,6 +13,7 @@ import doritos.doriroom.challenge.exception.ChallengeNotFoundException;
 import doritos.doriroom.challenge.exception.ChallengeStatusException;
 import doritos.doriroom.challenge.repository.ChallengeRepository;
 import doritos.doriroom.challenge.repository.UserChallengeRepository;
+import doritos.doriroom.global.cache.RedisCacheService;
 import doritos.doriroom.item.service.ItemService;
 import doritos.doriroom.tourApi.domain.AreaGroup;
 import doritos.doriroom.user.domain.User;
@@ -23,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -33,6 +36,7 @@ public class ChallengeService {
     private final UserChallengeRepository userChallengeRepository;
     private final ItemService itemService;
     private final AtlasService atlasService;
+    private final RedisCacheService redisCacheService;
 
     // endDate가 지난 도전과제 상태를 EXPIRED로 변경, 스케줄러에서 호출
     @Transactional
@@ -45,8 +49,19 @@ public class ChallengeService {
 
     @Transactional(readOnly = true)
     public List<ChallengeResponseDto> getChallengesByGroup(User user, ChallengeGroup challengeGroup, AreaGroup areaGroup){
-        // 요청 조건에 따라 필터링된 과제 리스트
-        List<Challenge> challenges = challengeFilterByGroup(challengeGroup, areaGroup);
+        // 그룹별로 사용할 캐시 키 정의
+        String cacheKeyByGroup = RedisCacheService.CHALLENGES_KEY + challengeGroup.toString() + (areaGroup != null ? "_" + areaGroup.toString() : "");
+
+        // 캐시에서 조회
+        Optional<List<Challenge>> cachedChallenges = redisCacheService.getCacheList(cacheKeyByGroup, new TypeReference<>() {});
+
+        List<Challenge> challenges;
+        if (cachedChallenges.isPresent()) { // 캐시에 있으면 가져옴
+            challenges = cachedChallenges.get();
+        } else {
+            challenges = challengeFilterByGroup(challengeGroup, areaGroup); // 없으면 db에서 조회
+            redisCacheService.setCache(cacheKeyByGroup, challenges, RedisCacheService.CHALLENGES_TTL); // 캐시에 저장해둠
+        }
 
         // 과제들에 대한 유저의 과제 상태 리스트 -> Map으로 변환
         Map<Long, UserChallenge> userChallengeMap = userChallengeRepository.findByUserAndChallengeInWithFetch(user, challenges).stream()

--- a/src/main/java/doritos/doriroom/challenge/service/ChallengeService.java
+++ b/src/main/java/doritos/doriroom/challenge/service/ChallengeService.java
@@ -50,10 +50,11 @@ public class ChallengeService {
     @Transactional(readOnly = true)
     public List<ChallengeResponseDto> getChallengesByGroup(User user, ChallengeGroup challengeGroup, AreaGroup areaGroup){
         // 그룹별로 사용할 캐시 키 정의
-        String cacheKeyByGroup = RedisCacheService.CHALLENGES_KEY + challengeGroup.toString() + (areaGroup != null ? "_" + areaGroup.toString() : "");
+        String cacheKeyByGroup = RedisCacheService.CHALLENGES_KEY + challengeGroup + (areaGroup != null ? ":" + areaGroup : "");
 
         // 캐시에서 조회
-        Optional<List<Challenge>> cachedChallenges = redisCacheService.getCacheList(cacheKeyByGroup, new TypeReference<>() {});
+        Optional<List<Challenge>> cachedChallenges = redisCacheService.getCacheList(
+                cacheKeyByGroup, new TypeReference<List<Challenge>>() {});
 
         List<Challenge> challenges;
         if (cachedChallenges.isPresent()) { // 캐시에 있으면 가져옴
@@ -61,6 +62,10 @@ public class ChallengeService {
         } else {
             challenges = challengeFilterByGroup(challengeGroup, areaGroup); // 없으면 db에서 조회
             redisCacheService.setCache(cacheKeyByGroup, challenges, RedisCacheService.CHALLENGES_TTL); // 캐시에 저장해둠
+        }
+
+        if (challenges.isEmpty()) {
+            return List.of();
         }
 
         // 과제들에 대한 유저의 과제 상태 리스트 -> Map으로 변환

--- a/src/main/java/doritos/doriroom/global/cache/RedisCacheService.java
+++ b/src/main/java/doritos/doriroom/global/cache/RedisCacheService.java
@@ -21,7 +21,7 @@ public class RedisCacheService {
     public static final String UPCOMING_EVENTS_KEY = "upcoming_events";
     public static final String ENDING_SOON_EVENTS_KEY = "ending_soon_events";
     public static final String POPULAR_DIARIES_KEY = "popular_diaries";
-    public static final String ALL_ITEM_KEY = "all_items";
+    public static final String ALL_ITEMS_KEY = "all_items";
     public static final String CHALLENGES_KEY = "challenges:";
 
     public static final Duration POPULAR_EVENTS_TTL = Duration.ofMinutes(30);

--- a/src/main/java/doritos/doriroom/global/cache/RedisCacheService.java
+++ b/src/main/java/doritos/doriroom/global/cache/RedisCacheService.java
@@ -21,11 +21,15 @@ public class RedisCacheService {
     public static final String UPCOMING_EVENTS_KEY = "upcoming_events";
     public static final String ENDING_SOON_EVENTS_KEY = "ending_soon_events";
     public static final String POPULAR_DIARIES_KEY = "popular_diaries";
+    public static final String ALL_ITEM_KEY = "all_items";
+    public static final String CHALLENGES_KEY = "challenges:";
 
     public static final Duration POPULAR_EVENTS_TTL = Duration.ofMinutes(30);
     public static final Duration UPCOMING_EVENTS_TTL = Duration.ofDays(1);
     public static final Duration ENDING_SOON_EVENTS_TTL = Duration.ofDays(1);
     public static final Duration POPULAR_DIARIES_TTL = Duration.ofMinutes(30);
+    public static final Duration ALL_ITEM_TTL = Duration.ofDays(1);
+    public static final Duration CHALLENGES_TTL = Duration.ofHours(1);
 
     //캐시 저장
     public <T> void setCache(String key, T data, Duration ttl) {

--- a/src/main/java/doritos/doriroom/global/cache/RedisCacheService.java
+++ b/src/main/java/doritos/doriroom/global/cache/RedisCacheService.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -76,8 +78,15 @@ public class RedisCacheService {
                 POPULAR_EVENTS_KEY,
                 UPCOMING_EVENTS_KEY,
                 ENDING_SOON_EVENTS_KEY,
-                POPULAR_DIARIES_KEY
+                POPULAR_DIARIES_KEY,
+                ALL_ITEMS_KEY
             ));
+            // challenge 캐시 삭제
+            Set<String> challengeKeys = redisTemplate.keys(CHALLENGES_KEY + "*");
+            if  (challengeKeys != null && !challengeKeys.isEmpty()) {
+                redisTemplate.delete(challengeKeys);
+            }
+
             log.info("All caches cleared successfully");
         } catch (Exception e) {
             log.error("Failed to clear all caches", e);

--- a/src/main/java/doritos/doriroom/item/service/ItemService.java
+++ b/src/main/java/doritos/doriroom/item/service/ItemService.java
@@ -64,7 +64,8 @@ public class ItemService {
     @Transactional(readOnly = true)
     public List<ItemResponse> getAllItems(User user) {
         // 캐시에서 아이템 조회
-        Optional<List<Item>> cachedItems = redisCacheService.getCacheList(RedisCacheService.ALL_ITEMS_KEY, new TypeReference<>() {});
+        Optional<List<Item>> cachedItems = redisCacheService.getCacheList(
+                RedisCacheService.ALL_ITEMS_KEY, new TypeReference<List<Item>>() {});
 
         List<Item> allItems;
         if (cachedItems.isPresent()) {

--- a/src/main/java/doritos/doriroom/item/service/ItemService.java
+++ b/src/main/java/doritos/doriroom/item/service/ItemService.java
@@ -1,5 +1,7 @@
 package doritos.doriroom.item.service;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import doritos.doriroom.global.cache.RedisCacheService;
 import doritos.doriroom.item.domain.Item;
 import doritos.doriroom.item.domain.ItemGroup;
 import doritos.doriroom.item.domain.ItemType;
@@ -35,6 +37,7 @@ public class ItemService {
     private final ItemRepository itemRepository;
     private final UserItemRepository userItemRepository;
     private final UserRepository userRepository;
+    private final RedisCacheService redisCacheService;
 
     /* ---- 사용자 아이템 추가 관련 (구매하는 경우 제외) ---- */
 
@@ -60,10 +63,22 @@ public class ItemService {
     // 전체 아이템 조회 (유저 보유 여부 포함)
     @Transactional(readOnly = true)
     public List<ItemResponse> getAllItems(User user) {
+        // 캐시에서 아이템 조회
+        Optional<List<Item>> cachedItems = redisCacheService.getCacheList(RedisCacheService.ALL_ITEMS_KEY, new TypeReference<>() {});
+
+        List<Item> allItems;
+        if (cachedItems.isPresent()) {
+            allItems = cachedItems.get(); // 캐시 값이 있으면 할당하여 사용
+        } else {
+            allItems = itemRepository.findAll(); // 캐시에 없으면 db에서 조회
+            redisCacheService.setCache(RedisCacheService.ALL_ITEMS_KEY, allItems, RedisCacheService.ALL_ITEM_TTL); // 캐시에 allItems 저장
+        }
+
+        // 유저의 보유 여부는 따로 조회
         Set<Long> ownedItemIds = userItemRepository.findByUser(user)
                 .stream().map(ui -> ui.getItem().getItemId()).collect(Collectors.toSet());
 
-        return itemRepository.findAll().stream()
+        return allItems.stream()
                 .map(i -> ItemResponse.from(i, ownedItemIds.contains(i.getItemId())))
                 .toList();
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

#137 

## 📝작업 내용

상점 전체 아이템과 도전과제 조회 api에 캐싱을 적용하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 성능 향상
  - 도전 과제 목록(그룹/지역 기준)과 아이템 전체 목록에 캐싱을 도입하여 로딩 속도와 화면 응답성이 크게 개선되었습니다.
  - 반복 조회 시 지연시간이 감소하고 서버 부하가 완화됩니다.
- 안정성
  - 동일 데이터 재사용으로 일시적 DB 지연 상황에서도 조회 안정성이 향상되었습니다.
- 변경 영향
  - 기능과 화면 흐름, API는 기존과 동일하며, 초기 조회 후 일정 기간 동안 최신 상태가 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->