### PR TITLE
feat(event): 축제 조회 시 관련 도전과제의 id를 응답에 추가

### DIFF
--- a/src/main/java/doritos/doriroom/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/doritos/doriroom/challenge/repository/ChallengeRepository.java
@@ -3,6 +3,7 @@ package doritos.doriroom.challenge.repository;
 import doritos.doriroom.challenge.domain.challenge.Challenge;
 import doritos.doriroom.challenge.domain.challenge.ChallengeGroup;
 import doritos.doriroom.challenge.domain.challenge.ChallengeType;
+import doritos.doriroom.event.domain.Event;
 import doritos.doriroom.tourApi.domain.AreaGroup;
 import lombok.NonNull;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,6 +17,7 @@ import java.util.Optional;
 public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
     @NonNull
     Optional<Challenge> findById(@NonNull Long challengeId); // 단일과제 조회
+    Optional<Challenge> findFirstByEvent(Event event); // 해당 이벤트와 관련된 도전과제  (첫 번째 하나만 조회)
 
     List<Challenge> findByChallengeType(ChallengeType challengeType); // 도전과제 타입별 리스트 조회
 

--- a/src/main/java/doritos/doriroom/event/dto/response/EventDetailResponseDto.java
+++ b/src/main/java/doritos/doriroom/event/dto/response/EventDetailResponseDto.java
@@ -6,54 +6,57 @@ import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 
 public record EventDetailResponseDto(
-    String title,
-    int contentId,
-    UUID eventId,
-    String startDate,
-    String endDate,
-    String addr1,
-    String addr2,
-    String areaName,
-    int areaCode,
-    String firstImage,
-    String secondImage,
-    int favoriteCount,
-    long diaryCount,
+        String title,
+        int contentId,
+        UUID eventId,
+        String startDate,
+        String endDate,
+        String addr1,
+        String addr2,
+        String areaName,
+        int areaCode,
+        String firstImage,
+        String secondImage,
+        int favoriteCount,
+        long diaryCount,
 
-    //상세정보
-    String sponsor1,
-    String sponsor2,
-    String useTimeFestival,
+        //상세정보
+        String sponsor1,
+        String sponsor2,
+        String useTimeFestival,
 
-    String eventIntro,
-    String eventContent,
+        String eventIntro,
+        String eventContent,
 
-    //위치정보
-    Double mapX,
-    Double mapY
+        //위치정보
+        Double mapX,
+        Double mapY,
+
+        Long relatedChallengeId // 관련 도전과제Id (없으면 null)
 ) {
-    public static EventDetailResponseDto from(Event event){
+    public static EventDetailResponseDto from(Event event, Long relatedChallengeId) {
         return new EventDetailResponseDto(
-            event.getTitle(),
-            event.getContentId(),
-            event.getEventId(),
-            event.getStartDate().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")),
-            event.getEndDate().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")),
-            event.getAddr1(),
-            event.getAddr2(),
-            AreaGroup.getAreaNameByAreaCode(event.getAreaCode()),
-            event.getAreaCode(),
-            event.getFirstImage(),
-            event.getSecondImage(),
-            event.getFavoriteCount(),
-            event.getDiaryCount(),
-            event.getSponsor1(),
-            event.getSponsor2(),
-            event.getUseTimeFestival(),
-            event.getEventIntro(),
-            event.getEventContent(),
-            event.getMapX(),
-            event.getMapY()
+                event.getTitle(),
+                event.getContentId(),
+                event.getEventId(),
+                event.getStartDate().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")),
+                event.getEndDate().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")),
+                event.getAddr1(),
+                event.getAddr2(),
+                AreaGroup.getAreaNameByAreaCode(event.getAreaCode()),
+                event.getAreaCode(),
+                event.getFirstImage(),
+                event.getSecondImage(),
+                event.getFavoriteCount(),
+                event.getDiaryCount(),
+                event.getSponsor1(),
+                event.getSponsor2(),
+                event.getUseTimeFestival(),
+                event.getEventIntro(),
+                event.getEventContent(),
+                event.getMapX(),
+                event.getMapY(),
+                relatedChallengeId
         );
     }
 }

--- a/src/main/java/doritos/doriroom/event/service/EventService.java
+++ b/src/main/java/doritos/doriroom/event/service/EventService.java
@@ -1,6 +1,8 @@
 package doritos.doriroom.event.service;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import doritos.doriroom.challenge.domain.challenge.Challenge;
+import doritos.doriroom.challenge.repository.ChallengeRepository;
 import doritos.doriroom.event.domain.Event;
 import doritos.doriroom.event.domain.EventDetailStatus;
 import doritos.doriroom.event.dto.request.EventItemFilterRequestDto;
@@ -34,21 +36,22 @@ public class EventService {
     private final TourApiService tourApiService;
     private final EventRepository eventRepository;
     private final RedisCacheService redisCacheService;
+    private final ChallengeRepository challengeRepository;
 
     @Transactional
     public void getAllEvents() {
         List<TourApiItemDto> items = tourApiService.fetchAllEvents();
 
         List<String> contentIds = items.stream()
-            .map(TourApiItemDto::getContentid)
-            .toList();
+                .map(TourApiItemDto::getContentid)
+                .toList();
 
         List<String> existingIds = eventRepository.findAllContentIdIn(contentIds);
 
         List<Event> newEvents = items.stream()
-            .filter(dto -> !existingIds.contains(dto.getContentid()))
-            .map(Event::fromEntity)
-            .toList();
+                .filter(dto -> !existingIds.contains(dto.getContentid()))
+                .map(Event::fromEntity)
+                .toList();
 
         eventRepository.saveAll(newEvents);
         log.info(" 총 {}개 이벤트 저장 완료", newEvents.size());
@@ -59,10 +62,10 @@ public class EventService {
         List<TourApiItemDto> items = tourApiService.fetchTodayEvents();
 
         List<Integer> contentIds = items.stream()
-            .map(TourApiItemDto::getContentid)
-            .filter(id -> id != null && !id.isBlank())
-            .map(Integer::parseInt)
-            .toList();
+                .map(TourApiItemDto::getContentid)
+                .filter(id -> id != null && !id.isBlank())
+                .map(Integer::parseInt)
+                .toList();
 
         List<Event> existingEvents = eventRepository.findEventsByContentIds(contentIds);
         Map<Integer, Event> existingEventMap = new HashMap<>();
@@ -118,7 +121,7 @@ public class EventService {
             if(event.getEventDetailStatus() == EventDetailStatus.PENDING) {
                 CompletableFuture<TourApiDetailIntroDto> introFuture = null;
                 CompletableFuture<List<TourApiDetailInfoDto>> infoFuture = null;
-                
+
                 try {
                     // 두 API를 비동기 호출
                     introFuture = tourApiService.fetchEventDetailIntro(event.getContentId());
@@ -181,9 +184,9 @@ public class EventService {
     public List<Event> getUpcomingEvents(){
         // 캐시에서 먼저 조회
         Optional<List<Event>> cachedEvents = redisCacheService.getCacheList(
-            RedisCacheService.UPCOMING_EVENTS_KEY,
-            new TypeReference<>() {
-            }
+                RedisCacheService.UPCOMING_EVENTS_KEY,
+                new TypeReference<>() {
+                }
         );
 
         if (cachedEvents.isPresent()) {
@@ -196,9 +199,9 @@ public class EventService {
 
         // 캐시에 저장
         redisCacheService.setCache(
-            RedisCacheService.UPCOMING_EVENTS_KEY,
-            events,
-            RedisCacheService.UPCOMING_EVENTS_TTL
+                RedisCacheService.UPCOMING_EVENTS_KEY,
+                events,
+                RedisCacheService.UPCOMING_EVENTS_TTL
         );
 
         return events;
@@ -207,9 +210,9 @@ public class EventService {
     public List<Event> getEndingSoonEvents() {
         // 캐시에서 먼저 조회
         Optional<List<Event>> cachedEvents = redisCacheService.getCacheList(
-            RedisCacheService.ENDING_SOON_EVENTS_KEY,
-            new TypeReference<>() {
-            }
+                RedisCacheService.ENDING_SOON_EVENTS_KEY,
+                new TypeReference<>() {
+                }
         );
 
         if (cachedEvents.isPresent()) {
@@ -222,9 +225,9 @@ public class EventService {
 
         // 캐시에 저장
         redisCacheService.setCache(
-            RedisCacheService.ENDING_SOON_EVENTS_KEY,
-            events,
-            RedisCacheService.ENDING_SOON_EVENTS_TTL
+                RedisCacheService.ENDING_SOON_EVENTS_KEY,
+                events,
+                RedisCacheService.ENDING_SOON_EVENTS_TTL
         );
 
         return events;
@@ -233,9 +236,9 @@ public class EventService {
     public List<Event> getPopularEvents(){
         // 캐시에서 먼저 조회
         Optional<List<Event>> cachedEvents = redisCacheService.getCacheList(
-            RedisCacheService.POPULAR_EVENTS_KEY,
-            new TypeReference<>() {
-            }
+                RedisCacheService.POPULAR_EVENTS_KEY,
+                new TypeReference<>() {
+                }
         );
 
         if (cachedEvents.isPresent()) {
@@ -247,9 +250,9 @@ public class EventService {
 
         // 캐시에 저장
         redisCacheService.setCache(
-            RedisCacheService.POPULAR_EVENTS_KEY,
-            events,
-            RedisCacheService.POPULAR_EVENTS_TTL
+                RedisCacheService.POPULAR_EVENTS_KEY,
+                events,
+                RedisCacheService.POPULAR_EVENTS_TTL
         );
 
         return events;
@@ -257,13 +260,16 @@ public class EventService {
 
     public Page<EventResponseDto> getFilteredEvents(EventItemFilterRequestDto request, Pageable pageable) {
         return eventRepository.findFiltered(request, pageable)
-            .map(EventResponseDto::from);
+                .map(EventResponseDto::from);
     }
 
     @Transactional
     public EventDetailResponseDto getEventDetail(UUID eventId) {
         Event event = eventRepository.findById(eventId)
-            .orElseThrow(EventNotFoundException::new);
+                .orElseThrow(EventNotFoundException::new);
+
+        // 관련 도전과제 Id (값이 없으면 null)
+        Long relatedChallengeId = challengeRepository.findFirstByEvent(event).map(Challenge::getId).orElse(null);
 
         //DB에 상세정보가 없으면 tourAPI 호출
         if(event.getEventDetailStatus() == EventDetailStatus.PENDING){
@@ -276,8 +282,8 @@ public class EventService {
 
                 // 타임아웃 설정 (30초)
                 CompletableFuture.allOf(
-                    introFuture.orTimeout(30, TimeUnit.SECONDS),
-                    infoFuture.orTimeout(30, TimeUnit.SECONDS)
+                        introFuture.orTimeout(30, TimeUnit.SECONDS),
+                        infoFuture.orTimeout(30, TimeUnit.SECONDS)
                 ).join();
 
                 // 결과 가져오기
@@ -297,11 +303,11 @@ public class EventService {
                 log.error("축제 상세 정보 업데이트 실패: eventId={}, error={}", eventId, e.getMessage());
                 currentStatus = EventDetailStatus.FAILED;
             }
-            
+
             event.changeEventDetailStatus(currentStatus);
             eventRepository.save(event);
         }
 
-        return EventDetailResponseDto.from(event);
+        return EventDetailResponseDto.from(event, relatedChallengeId);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#146 

## 📝작업 내용

축제 조회 시 관련 도전과제의 id를 응답에 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 이벤트 상세에 연관된 도전과제 정보를 함께 제공하여, 관련 도전과제로 빠르게 이동할 수 있습니다.
* Bug Fixes
  * 외부 API 지연/오류 상황에서 상세 업데이트가 실패하던 문제를 완화하고, 삭제된 이벤트 상태 반영을 개선했습니다.
* Chores
  * 오늘의 이벤트 업데이트 로직을 보강해 신규/기존 이벤트를 더 정확히 반영하고, 캐시 무효화를 정교화하여 “곧 종료”/“인기”/“예정” 목록의 최신성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->