### PR TITLE
feat: http로 들어오는 이미지 url을 https로 저장

### DIFF
--- a/src/main/java/doritos/doriroom/event/domain/Event.java
+++ b/src/main/java/doritos/doriroom/event/domain/Event.java
@@ -114,8 +114,8 @@ public class Event {
             .eventId(UUID.randomUUID())
             .contentId(parseInt(dto.getContentid()))
             .contentTypeId(parseInt(dto.getContenttypeid()))
-            .firstImage(dto.getFirstimage())
-            .secondImage(dto.getFirstimage2())
+            .firstImage(dto.getFirstimage() != null ? dto.getFirstimage().replace("http://", "https://") : null)
+            .secondImage(dto.getFirstimage2() != null ? dto.getFirstimage2().replace("http://", "https://") : null)
             .title(dto.getTitle())
             .startDate(LocalDate.parse(dto.getEventstartdate(), formatter))
             .endDate(LocalDate.parse(dto.getEventenddate(), formatter))
@@ -138,8 +138,8 @@ public class Event {
     }
 
     public void updateFrom(Event newEvent) {
-        this.firstImage = newEvent.firstImage;
-        this.secondImage = newEvent.secondImage;
+        this.firstImage = newEvent.firstImage != null ? newEvent.firstImage.replace("http://", "https://") : null;
+        this.secondImage = newEvent.secondImage != null ? newEvent.secondImage.replace("http://", "https://") : null;
         this.title = newEvent.title;
         this.startDate = newEvent.startDate;
         this.endDate = newEvent.endDate;


### PR DESCRIPTION
## #️⃣연관된 이슈

#148 

## 📝작업 내용
1. DB의 축제이미지URL을 https로 변경했습니다.
2. 앞으로 들어오는 축제에 대해 https로 저장하도록 했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 이벤트의 첫 번째/두 번째 이미지 URL을 자동으로 https로 변환하여 항상 보안 연결로 로드되도록 개선했습니다.
  - 기존 http 링크로 인해 발생하던 혼합 콘텐츠 경고와 일부 브라우저에서 이미지가 표시되지 않는 문제를 해소했습니다.
  - 이미지 주소가 비어 있거나 누락된 경우를 안전하게 처리해 깨진 썸네일 노출 및 예기치 않은 오류 발생 가능성을 줄였으며, 전반적인 이미지 로딩 안정성과 일관성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->