### PR TITLE
fix(item): boolean 타입의 필드명에서 is를 제거

### DIFF
--- a/src/main/java/doritos/doriroom/auth/service/AuthService.java
+++ b/src/main/java/doritos/doriroom/auth/service/AuthService.java
@@ -134,7 +134,7 @@ public class AuthService {
 
         userRepository.save(user);
 
-        List<Item> defaultItems = itemRepository.findByIsDefaultTrue(); // 기본 아이템 전부 조회
+        List<Item> defaultItems = itemRepository.findByDefaultItemTrue(); // 기본 아이템 전부 조회
 
         // 신규 유저 기본 아이템 지급 및 착용
         List<UserItem> newUserItems = defaultItems.stream()

--- a/src/main/java/doritos/doriroom/auth/service/AuthService.java
+++ b/src/main/java/doritos/doriroom/auth/service/AuthService.java
@@ -141,7 +141,7 @@ public class AuthService {
                 .map(item -> UserItem.builder()
                         .user(user)
                         .item(item)
-                        .isEquipped(true) // 착용 상태로 지정
+                        .equipped(true) // 착용 상태로 지정
                         .build())
                 .collect(Collectors.toList());
         userItemRepository.saveAll(newUserItems);

--- a/src/main/java/doritos/doriroom/global/DataInitializer.java
+++ b/src/main/java/doritos/doriroom/global/DataInitializer.java
@@ -129,67 +129,67 @@ public class DataInitializer implements ApplicationRunner {
     private void createInitialItems() {
         List<Item> items = List.of(
                 // 1~6: SHELF (COMMON)
-                Item.builder().name("사물함 선반").itemType(ItemType.SHELF).itemGroup(ItemGroup.COMMON).price(10L).theme(CollectionTheme.CLASSROOM).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("굴뚝 선반").itemType(ItemType.SHELF).itemGroup(ItemGroup.COMMON).price(10L).theme(CollectionTheme.WINTER).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("캠핑의자 선반").itemType(ItemType.SHELF).itemGroup(ItemGroup.COMMON).price(20L).theme(CollectionTheme.PICNIC).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("파라솔 선반").itemType(ItemType.SHELF).itemGroup(ItemGroup.COMMON).price(30L).theme(CollectionTheme.SUMMER).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("아이스크림 선반").itemType(ItemType.SHELF).itemGroup(ItemGroup.COMMON).price(40L).theme(CollectionTheme.DESSERT).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("선물 선반").itemType(ItemType.SHELF).itemGroup(ItemGroup.COMMON).price(50L).theme(CollectionTheme.BIRTHDAY).isPurchasable(true).isDefault(false).build(),
+                Item.builder().name("사물함 선반").itemType(ItemType.SHELF).itemGroup(ItemGroup.COMMON).price(10L).theme(CollectionTheme.CLASSROOM).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("굴뚝 선반").itemType(ItemType.SHELF).itemGroup(ItemGroup.COMMON).price(10L).theme(CollectionTheme.WINTER).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("캠핑의자 선반").itemType(ItemType.SHELF).itemGroup(ItemGroup.COMMON).price(20L).theme(CollectionTheme.PICNIC).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("파라솔 선반").itemType(ItemType.SHELF).itemGroup(ItemGroup.COMMON).price(30L).theme(CollectionTheme.SUMMER).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("아이스크림 선반").itemType(ItemType.SHELF).itemGroup(ItemGroup.COMMON).price(40L).theme(CollectionTheme.DESSERT).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("선물 선반").itemType(ItemType.SHELF).itemGroup(ItemGroup.COMMON).price(50L).theme(CollectionTheme.BIRTHDAY).purchasable(true).defaultItem(false).build(),
 
                 // 7~12: OBJECT (COMMON)
-                Item.builder().name("책").itemType(ItemType.OBJECT).itemGroup(ItemGroup.COMMON).price(10L).theme(CollectionTheme.CLASSROOM).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("이글루").itemType(ItemType.OBJECT).itemGroup(ItemGroup.COMMON).price(20L).theme(CollectionTheme.WINTER).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("사과바구니").itemType(ItemType.OBJECT).itemGroup(ItemGroup.COMMON).price(30L).theme(CollectionTheme.PICNIC).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("해바라기").itemType(ItemType.OBJECT).itemGroup(ItemGroup.COMMON).price(40L).theme(CollectionTheme.SUMMER).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("사탕다발").itemType(ItemType.OBJECT).itemGroup(ItemGroup.COMMON).price(50L).theme(CollectionTheme.DESSERT).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("풍선개").itemType(ItemType.OBJECT).itemGroup(ItemGroup.COMMON).price(60L).theme(CollectionTheme.BIRTHDAY).isPurchasable(true).isDefault(false).build(),
+                Item.builder().name("책").itemType(ItemType.OBJECT).itemGroup(ItemGroup.COMMON).price(10L).theme(CollectionTheme.CLASSROOM).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("이글루").itemType(ItemType.OBJECT).itemGroup(ItemGroup.COMMON).price(20L).theme(CollectionTheme.WINTER).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("사과바구니").itemType(ItemType.OBJECT).itemGroup(ItemGroup.COMMON).price(30L).theme(CollectionTheme.PICNIC).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("해바라기").itemType(ItemType.OBJECT).itemGroup(ItemGroup.COMMON).price(40L).theme(CollectionTheme.SUMMER).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("사탕다발").itemType(ItemType.OBJECT).itemGroup(ItemGroup.COMMON).price(50L).theme(CollectionTheme.DESSERT).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("풍선개").itemType(ItemType.OBJECT).itemGroup(ItemGroup.COMMON).price(60L).theme(CollectionTheme.BIRTHDAY).purchasable(true).defaultItem(false).build(),
 
                 // 13~18: WINDOW (COMMON)
-                Item.builder().name("비행기 창문").itemType(ItemType.WINDOW).itemGroup(ItemGroup.COMMON).price(10L).theme(CollectionTheme.CLASSROOM).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("눈밭 창문").itemType(ItemType.WINDOW).itemGroup(ItemGroup.COMMON).price(20L).theme(CollectionTheme.WINTER).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("자연 창문").itemType(ItemType.WINDOW).itemGroup(ItemGroup.COMMON).price(30L).theme(CollectionTheme.PICNIC).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("야자수 창문").itemType(ItemType.WINDOW).itemGroup(ItemGroup.COMMON).price(40L).theme(CollectionTheme.SUMMER).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("초콜릿 창문").itemType(ItemType.WINDOW).itemGroup(ItemGroup.COMMON).price(50L).theme(CollectionTheme.DESSERT).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("전구 창문").itemType(ItemType.WINDOW).itemGroup(ItemGroup.COMMON).price(60L).theme(CollectionTheme.BIRTHDAY).isPurchasable(true).isDefault(false).build(),
+                Item.builder().name("비행기 창문").itemType(ItemType.WINDOW).itemGroup(ItemGroup.COMMON).price(10L).theme(CollectionTheme.CLASSROOM).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("눈밭 창문").itemType(ItemType.WINDOW).itemGroup(ItemGroup.COMMON).price(20L).theme(CollectionTheme.WINTER).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("자연 창문").itemType(ItemType.WINDOW).itemGroup(ItemGroup.COMMON).price(30L).theme(CollectionTheme.PICNIC).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("야자수 창문").itemType(ItemType.WINDOW).itemGroup(ItemGroup.COMMON).price(40L).theme(CollectionTheme.SUMMER).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("초콜릿 창문").itemType(ItemType.WINDOW).itemGroup(ItemGroup.COMMON).price(50L).theme(CollectionTheme.DESSERT).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("전구 창문").itemType(ItemType.WINDOW).itemGroup(ItemGroup.COMMON).price(60L).theme(CollectionTheme.BIRTHDAY).purchasable(true).defaultItem(false).build(),
 
                 // 19~24: FLOOR (COMMON)
-                Item.builder().name("교실 바닥").itemType(ItemType.FLOOR).itemGroup(ItemGroup.COMMON).price(10L).theme(CollectionTheme.CLASSROOM).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("얼음 바닥").itemType(ItemType.FLOOR).itemGroup(ItemGroup.COMMON).price(20L).theme(CollectionTheme.WINTER).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("식탁보 바닥").itemType(ItemType.FLOOR).itemGroup(ItemGroup.COMMON).price(30L).theme(CollectionTheme.PICNIC).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("모래사장 바닥").itemType(ItemType.FLOOR).itemGroup(ItemGroup.COMMON).price(40L).theme(CollectionTheme.SUMMER).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("쿠키 바닥").itemType(ItemType.FLOOR).itemGroup(ItemGroup.COMMON).price(50L).theme(CollectionTheme.DESSERT).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("핑크 카펫 바닥").itemType(ItemType.FLOOR).itemGroup(ItemGroup.COMMON).price(60L).theme(CollectionTheme.BIRTHDAY).isPurchasable(true).isDefault(false).build(),
+                Item.builder().name("교실 바닥").itemType(ItemType.FLOOR).itemGroup(ItemGroup.COMMON).price(10L).theme(CollectionTheme.CLASSROOM).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("얼음 바닥").itemType(ItemType.FLOOR).itemGroup(ItemGroup.COMMON).price(20L).theme(CollectionTheme.WINTER).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("식탁보 바닥").itemType(ItemType.FLOOR).itemGroup(ItemGroup.COMMON).price(30L).theme(CollectionTheme.PICNIC).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("모래사장 바닥").itemType(ItemType.FLOOR).itemGroup(ItemGroup.COMMON).price(40L).theme(CollectionTheme.SUMMER).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("쿠키 바닥").itemType(ItemType.FLOOR).itemGroup(ItemGroup.COMMON).price(50L).theme(CollectionTheme.DESSERT).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("핑크 카펫 바닥").itemType(ItemType.FLOOR).itemGroup(ItemGroup.COMMON).price(60L).theme(CollectionTheme.BIRTHDAY).purchasable(true).defaultItem(false).build(),
 
                 // 25~30: WALL (COMMON)
-                Item.builder().name("칠판 벽지").itemType(ItemType.WALL).itemGroup(ItemGroup.COMMON).price(10L).theme(CollectionTheme.CLASSROOM).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("눈꽃 벽지").itemType(ItemType.WALL).itemGroup(ItemGroup.COMMON).price(20L).theme(CollectionTheme.WINTER).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("구름 벽지").itemType(ItemType.WALL).itemGroup(ItemGroup.COMMON).price(30L).theme(CollectionTheme.PICNIC).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("조개 벽지").itemType(ItemType.WALL).itemGroup(ItemGroup.COMMON).price(40L).theme(CollectionTheme.SUMMER).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("롤리팝 벽지").itemType(ItemType.WALL).itemGroup(ItemGroup.COMMON).price(50L).theme(CollectionTheme.DESSERT).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("풍선 벽지").itemType(ItemType.WALL).itemGroup(ItemGroup.COMMON).price(60L).theme(CollectionTheme.BIRTHDAY).isPurchasable(true).isDefault(false).build(),
+                Item.builder().name("칠판 벽지").itemType(ItemType.WALL).itemGroup(ItemGroup.COMMON).price(10L).theme(CollectionTheme.CLASSROOM).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("눈꽃 벽지").itemType(ItemType.WALL).itemGroup(ItemGroup.COMMON).price(20L).theme(CollectionTheme.WINTER).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("구름 벽지").itemType(ItemType.WALL).itemGroup(ItemGroup.COMMON).price(30L).theme(CollectionTheme.PICNIC).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("조개 벽지").itemType(ItemType.WALL).itemGroup(ItemGroup.COMMON).price(40L).theme(CollectionTheme.SUMMER).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("롤리팝 벽지").itemType(ItemType.WALL).itemGroup(ItemGroup.COMMON).price(50L).theme(CollectionTheme.DESSERT).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("풍선 벽지").itemType(ItemType.WALL).itemGroup(ItemGroup.COMMON).price(60L).theme(CollectionTheme.BIRTHDAY).purchasable(true).defaultItem(false).build(),
 
                 // 31~37: APPAREL (COMMON)
-                Item.builder().name("도리").itemType(ItemType.APPAREL).itemGroup(ItemGroup.COMMON).price(0L).isPurchasable(false).isDefault(true).build(), // default 아이템
-                Item.builder().name("학사모 도리").itemType(ItemType.APPAREL).itemGroup(ItemGroup.COMMON).price(10L).theme(CollectionTheme.CLASSROOM).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("목도리 도리").itemType(ItemType.APPAREL).itemGroup(ItemGroup.COMMON).price(20L).theme(CollectionTheme.WINTER).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("빨간망토 도리").itemType(ItemType.APPAREL).itemGroup(ItemGroup.COMMON).price(30L).theme(CollectionTheme.PICNIC).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("튜브 도리").itemType(ItemType.APPAREL).itemGroup(ItemGroup.COMMON).price(40L).theme(CollectionTheme.SUMMER).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("메론빵 도리").itemType(ItemType.APPAREL).itemGroup(ItemGroup.COMMON).price(50L).theme(CollectionTheme.DESSERT).isPurchasable(true).isDefault(false).build(),
-                Item.builder().name("생일파티 도리").itemType(ItemType.APPAREL).itemGroup(ItemGroup.COMMON).price(60L).theme(CollectionTheme.BIRTHDAY).isPurchasable(true).isDefault(false).build(),
+                Item.builder().name("도리").itemType(ItemType.APPAREL).itemGroup(ItemGroup.COMMON).price(0L).purchasable(false).defaultItem(true).build(), // default 아이템
+                Item.builder().name("학사모 도리").itemType(ItemType.APPAREL).itemGroup(ItemGroup.COMMON).price(10L).theme(CollectionTheme.CLASSROOM).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("목도리 도리").itemType(ItemType.APPAREL).itemGroup(ItemGroup.COMMON).price(20L).theme(CollectionTheme.WINTER).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("빨간망토 도리").itemType(ItemType.APPAREL).itemGroup(ItemGroup.COMMON).price(30L).theme(CollectionTheme.PICNIC).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("튜브 도리").itemType(ItemType.APPAREL).itemGroup(ItemGroup.COMMON).price(40L).theme(CollectionTheme.SUMMER).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("메론빵 도리").itemType(ItemType.APPAREL).itemGroup(ItemGroup.COMMON).price(50L).theme(CollectionTheme.DESSERT).purchasable(true).defaultItem(false).build(),
+                Item.builder().name("생일파티 도리").itemType(ItemType.APPAREL).itemGroup(ItemGroup.COMMON).price(60L).theme(CollectionTheme.BIRTHDAY).purchasable(true).defaultItem(false).build(),
 
                 // 38~40: 기본템 (COMMON, Default = true)
-                Item.builder().name("기본 선반").itemType(ItemType.SHELF).itemGroup(ItemGroup.COMMON).price(0L).isPurchasable(false).isDefault(true).build(),
-                Item.builder().name("기본 바닥").itemType(ItemType.FLOOR).itemGroup(ItemGroup.COMMON).price(0L).isPurchasable(false).isDefault(true).build(),
-                Item.builder().name("기본 창문").itemType(ItemType.WINDOW).itemGroup(ItemGroup.COMMON).price(0L).isPurchasable(false).isDefault(true).build(),
+                Item.builder().name("기본 선반").itemType(ItemType.SHELF).itemGroup(ItemGroup.COMMON).price(0L).purchasable(false).defaultItem(true).build(),
+                Item.builder().name("기본 바닥").itemType(ItemType.FLOOR).itemGroup(ItemGroup.COMMON).price(0L).purchasable(false).defaultItem(true).build(),
+                Item.builder().name("기본 창문").itemType(ItemType.WINDOW).itemGroup(ItemGroup.COMMON).price(0L).purchasable(false).defaultItem(true).build(),
 
                 // 41~47: AREA 아이템
-                Item.builder().name("감귤 도리").itemType(ItemType.APPAREL).itemGroup(ItemGroup.AREA).areaGroup(AreaGroup.JEJU).price(0L).isPurchasable(false).isDefault(false).build(),
-                Item.builder().name("복숭아 도리").itemType(ItemType.APPAREL).itemGroup(ItemGroup.AREA).areaGroup(AreaGroup.CHUNGNAM).price(0L).isPurchasable(false).isDefault(false).build(),
-                Item.builder().name("부산어묵 도리").itemType(ItemType.APPAREL).itemGroup(ItemGroup.AREA).areaGroup(AreaGroup.GYEONGSANG).price(0L).isPurchasable(false).isDefault(false).build(),
-                Item.builder().name("반달가슴곰 인형").itemType(ItemType.OBJECT).itemGroup(ItemGroup.AREA).areaGroup(AreaGroup.GANGWON).price(0L).isPurchasable(false).isDefault(false).build(),
-                Item.builder().name("빨간버스").itemType(ItemType.OBJECT).itemGroup(ItemGroup.AREA).areaGroup(AreaGroup.GYEONGGI).price(0L).isPurchasable(false).isDefault(false).build(),
-                Item.builder().name("해치 인형").itemType(ItemType.OBJECT).itemGroup(ItemGroup.AREA).areaGroup(AreaGroup.SEOUL).price(0L).isPurchasable(false).isDefault(false).build(),
-                Item.builder().name("토용 도리").itemType(ItemType.OBJECT).itemGroup(ItemGroup.AREA).areaGroup(AreaGroup.JEOLLA).price(0L).isPurchasable(false).isDefault(false).build()
+                Item.builder().name("감귤 도리").itemType(ItemType.APPAREL).itemGroup(ItemGroup.AREA).areaGroup(AreaGroup.JEJU).price(0L).purchasable(false).defaultItem(false).build(),
+                Item.builder().name("복숭아 도리").itemType(ItemType.APPAREL).itemGroup(ItemGroup.AREA).areaGroup(AreaGroup.CHUNGNAM).price(0L).purchasable(false).defaultItem(false).build(),
+                Item.builder().name("부산어묵 도리").itemType(ItemType.APPAREL).itemGroup(ItemGroup.AREA).areaGroup(AreaGroup.GYEONGSANG).price(0L).purchasable(false).defaultItem(false).build(),
+                Item.builder().name("반달가슴곰 인형").itemType(ItemType.OBJECT).itemGroup(ItemGroup.AREA).areaGroup(AreaGroup.GANGWON).price(0L).purchasable(false).defaultItem(false).build(),
+                Item.builder().name("빨간버스").itemType(ItemType.OBJECT).itemGroup(ItemGroup.AREA).areaGroup(AreaGroup.GYEONGGI).price(0L).purchasable(false).defaultItem(false).build(),
+                Item.builder().name("해치 인형").itemType(ItemType.OBJECT).itemGroup(ItemGroup.AREA).areaGroup(AreaGroup.SEOUL).price(0L).purchasable(false).defaultItem(false).build(),
+                Item.builder().name("토용 도리").itemType(ItemType.OBJECT).itemGroup(ItemGroup.AREA).areaGroup(AreaGroup.JEOLLA).price(0L).purchasable(false).defaultItem(false).build()
         );
 
         itemRepository.saveAll(items);

--- a/src/main/java/doritos/doriroom/item/domain/Item.java
+++ b/src/main/java/doritos/doriroom/item/domain/Item.java
@@ -37,9 +37,9 @@ public class Item {
     private CollectionTheme theme;
 
     @Column(nullable = false)
-    private boolean isPurchasable; // true: 구매 가능, false: 이벤트/한정 지급
+    private boolean purchasable; // true: 구매 가능, false: 이벤트/한정 지급
 
     @Column(nullable = false)
     @Builder.Default
-    private boolean isDefault = false; // 아이템이 기본 아이템인지 확인
+    private boolean defaultItem = false; // 아이템이 기본 아이템인지 확인
 }

--- a/src/main/java/doritos/doriroom/item/domain/Item.java
+++ b/src/main/java/doritos/doriroom/item/domain/Item.java
@@ -36,10 +36,10 @@ public class Item {
     @Column(length = 50)
     private CollectionTheme theme;
 
-    @Column(name = "is_purchasable", nullable = false)
+    @Column(nullable = false)
     private boolean purchasable; // true: 구매 가능, false: 이벤트/한정 지급
 
-    @Column(name = "is_default", nullable = false)
+    @Column(nullable = false)
     @Builder.Default
     private boolean defaultItem = false; // 아이템이 기본 아이템인지 확인
 }

--- a/src/main/java/doritos/doriroom/item/domain/Item.java
+++ b/src/main/java/doritos/doriroom/item/domain/Item.java
@@ -36,10 +36,10 @@ public class Item {
     @Column(length = 50)
     private CollectionTheme theme;
 
-    @Column(nullable = false)
+    @Column(name = "is_purchasable", nullable = false)
     private boolean purchasable; // true: 구매 가능, false: 이벤트/한정 지급
 
-    @Column(nullable = false)
+    @Column(name = "is_default", nullable = false)
     @Builder.Default
     private boolean defaultItem = false; // 아이템이 기본 아이템인지 확인
 }

--- a/src/main/java/doritos/doriroom/item/domain/UserItem.java
+++ b/src/main/java/doritos/doriroom/item/domain/UserItem.java
@@ -28,10 +28,10 @@ public class UserItem {
 
     @Column(nullable = false)
     @Builder.Default
-    private boolean isEquipped = false; // 착용 여부 상태
+    private boolean equipped = false; // 착용 여부 상태
 
     // 아이템 착용/해제
-    public void equip(){    this.isEquipped = true; }
-    public void unequip(){  this.isEquipped = false; }
+    public void equip(){    this.equipped = true; }
+    public void unequip(){  this.equipped = false; }
 
 }

--- a/src/main/java/doritos/doriroom/item/domain/UserItem.java
+++ b/src/main/java/doritos/doriroom/item/domain/UserItem.java
@@ -26,7 +26,7 @@ public class UserItem {
     @ManyToOne(fetch = FetchType.LAZY)
     private Item item;
 
-    @Column(nullable = false)
+    @Column(name = "is_equipped", nullable = false)
     @Builder.Default
     private boolean equipped = false; // 착용 여부 상태
 

--- a/src/main/java/doritos/doriroom/item/domain/UserItem.java
+++ b/src/main/java/doritos/doriroom/item/domain/UserItem.java
@@ -26,7 +26,7 @@ public class UserItem {
     @ManyToOne(fetch = FetchType.LAZY)
     private Item item;
 
-    @Column(name = "is_equipped", nullable = false)
+    @Column(nullable = false)
     @Builder.Default
     private boolean equipped = false; // 착용 여부 상태
 

--- a/src/main/java/doritos/doriroom/item/dto/response/EquipItemResponse.java
+++ b/src/main/java/doritos/doriroom/item/dto/response/EquipItemResponse.java
@@ -11,7 +11,7 @@ public record EquipItemResponse(
         boolean isEquipped
 
 ) {
-    private static EquipItemResponse from(Long equippedItemId, String name, ItemType itemType, boolean equipped) {
+    public static EquipItemResponse of(Long equippedItemId, String name, ItemType itemType, boolean equipped) {
         return EquipItemResponse.builder()
                 .equippedItemId(equippedItemId)
                 .name(name)

--- a/src/main/java/doritos/doriroom/item/dto/response/ItemResponse.java
+++ b/src/main/java/doritos/doriroom/item/dto/response/ItemResponse.java
@@ -33,7 +33,7 @@ public record ItemResponse (
                 .theme(i.getTheme())
                 .isPurchasable(i.isPurchasable())
                 .isOwned(isOwned)
-                .isDefault(i.isDefault())
+                .isDefault(i.isDefaultItem())
                 .build();
     }
 }

--- a/src/main/java/doritos/doriroom/item/repository/ItemRepository.java
+++ b/src/main/java/doritos/doriroom/item/repository/ItemRepository.java
@@ -13,7 +13,7 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     Optional<Item> findById(Long itemId); // 아이템 단일 조회
     boolean existsByName(String name);
 
-    List<Item> findByIsDefaultTrue(); // 기본 아이템 전부 조회
+    List<Item> findByDefaultItemTrue(); // 기본 아이템 전부 조회
     List<Item> findByItemGroup(ItemGroup itemGroup); // COMMON 아이템 조회 or AREA 아이템 전체 조회
     List<Item> findByItemGroupAndAreaGroup(ItemGroup itemGroup, AreaGroup areaGroup); // 특정 지역별 아이템 조회 (ex JEJU)
     List<Item> findByItemType(ItemType itemType); // 타입별 아이템 조회

--- a/src/main/java/doritos/doriroom/item/repository/UserItemRepository.java
+++ b/src/main/java/doritos/doriroom/item/repository/UserItemRepository.java
@@ -18,8 +18,8 @@ public interface UserItemRepository extends JpaRepository<UserItem, Long> {
     List<UserItem> findByUserAndItem_ItemType(User user, ItemType itemType); // 유저가 보유한 타입별 아이템 조회
 
     Optional<UserItem> findByUserAndItem(User user, Item item); // 유저가 보유한 아이템 단일 조회
-    Optional<UserItem> findByUserAndItem_ItemTypeAndIsEquippedTrue(User user, ItemType itemType); // 유저가 착용한 타입별 아이템 조회
+    Optional<UserItem> findByUserAndItem_ItemTypeAndEquippedTrue(User user, ItemType itemType); // 유저가 착용한 타입별 아이템 조회
 
     boolean existsByUserAndItem(User user, Item item); // 이미 보유하고 있는지 확인
-    List<UserItem> findByUserAndIsEquippedTrue(User user); // 착용 중인 아이템들 조회
+    List<UserItem> findByUserAndEquippedTrue(User user); // 착용 중인 아이템들 조회
 }

--- a/src/main/java/doritos/doriroom/item/service/ItemService.java
+++ b/src/main/java/doritos/doriroom/item/service/ItemService.java
@@ -206,7 +206,7 @@ public class ItemService {
                 .orElseThrow(NotOwnedException::new);
 
         // 해당 타입의 기존 착용 아이템이 있는지 여부 확인
-        Optional<UserItem> currentlyEquippedItem = userItemRepository.findByUserAndItem_ItemTypeAndIsEquippedTrue(user, item.getItemType());
+        Optional<UserItem> currentlyEquippedItem = userItemRepository.findByUserAndItem_ItemTypeAndEquippedTrue(user, item.getItemType());
 
         // 유저 아이템의 착용 상태
         boolean isEquipped = userItem.isEquipped();
@@ -223,7 +223,7 @@ public class ItemService {
 
         userItemRepository.save(userItem);
 
-        return new EquipItemResponse(
+        return EquipItemResponse.of(
                 item.getItemId(),
                 item.getName(),
                 item.getItemType(),
@@ -234,7 +234,7 @@ public class ItemService {
     // 현재 착용 중인 아이템 조회
     @Transactional(readOnly = true)
     public List<EquippedItemResponse> getEquippedItems(User user) {
-        return userItemRepository.findByUserAndIsEquippedTrue(user)
+        return userItemRepository.findByUserAndEquippedTrue(user)
                 .stream().map(EquippedItemResponse::from).toList();
     }
 
@@ -243,7 +243,7 @@ public class ItemService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UsernameNotFoundException("유저를 찾을 수 없습니다."));
 
-        return userItemRepository.findByUserAndIsEquippedTrue(user)
+        return userItemRepository.findByUserAndEquippedTrue(user)
                 .stream().map(EquippedItemResponse::from).toList();
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#150 

## 📝작업 내용

boolean 타입의 필드 isPurchasable isDefault isEquipped의 이름을 수정하였습니다.
-> purchasable, defaultItem, equipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - 아이템 및 사용자 아이템의 상태 플래그명과 빌더/접근자명을 일관되게 정리했습니다.
  - 초기 데이터 생성과 회원 가입 시 기본 아이템 할당 로직 호출 방식이 새 이름에 맞게 갱신되었습니다.
  - 일부 생성자/팩토리 진입점의 가시성이 변경되어 외부 통합 시 호출 방식에 영향이 있을 수 있습니다.
  - 사용자 동작, 기본값과 기능에는 변경이 없습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->