### PR TITLE
feat(auth): signup API에서 이미지 필드 제거

### DIFF
--- a/src/main/java/doritos/doriroom/auth/controller/AuthController.java
+++ b/src/main/java/doritos/doriroom/auth/controller/AuthController.java
@@ -41,9 +41,8 @@ public class AuthController {
 
     @PostMapping("/signup")
     @Operation(summary = "회원가입")
-    public ApiResponse<Void> signup(@RequestPart("request") @Valid SignupRequestDto request,
-                                    @RequestPart(value = "image", required = false) MultipartFile image){
-        authService.signup(request, image);
+    public ApiResponse<Void> signup(@RequestBody @Valid SignupRequestDto request){
+        authService.signup(request);
         return ApiResponse.ok();
     }
 

--- a/src/main/java/doritos/doriroom/auth/service/AuthService.java
+++ b/src/main/java/doritos/doriroom/auth/service/AuthService.java
@@ -98,7 +98,7 @@ public class AuthService {
         redisTemplate.opsForValue().set(verifiedKey, "verified", Duration.ofSeconds(VERIFIED_EXPIRE_SECONDS));
     }
 
-    public void signup(SignupRequestDto request, MultipartFile image) {
+    public void signup(SignupRequestDto request) {
         // 이메일 인증 완료 여부 확인
         String verifiedKey = VERIFIED_KEY_PREFIX.getValue() + request.email();
         String verified = (String) redisTemplate.opsForValue().get(verifiedKey);
@@ -118,19 +118,12 @@ public class AuthService {
             throw new DuplicateException("이메일");
         }
 
-        // 프로필 이미지 등록
-        String profileImageUrl = null;
-        if (image != null && !image.isEmpty()){
-            profileImageUrl = s3Uploader.uploadFile(image, "profile_image"); // s3에 업로드 후 url 반환
-        }
-
         User user = User.builder()
                 .userId(UUID.randomUUID())
                 .username(request.username())
                 .email(request.email())
                 .password(encoder.encode(request.password()))
                 .nickname(request.nickname())
-                .profileImageUrl(profileImageUrl)
                 .build();
 
         userRepository.save(user);


### PR DESCRIPTION
## #️⃣연관된 이슈

#157 

## 📝작업 내용

signup API에서 이미지 필드 제거했습니다.
Content-Type을 json으로 유지하고, 이미지 api를 별도 호출하도록 변경했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 회원가입 플로우 단순화: 멀티파트(본문+이미지) 입력을 단일 요청 본문으로 통합했습니다.
  - 가입 시 프로필 이미지 업로드 단계가 제거되어, 회원가입 과정에서 이미지를 첨부할 수 없습니다.
  - 기존 가입 중 설정되던 프로필 이미지 URL 저장 로직이 삭제되었습니다.
  - 가입 기능은 이메일 인증 확인, 중복 검사, 사용자 생성 등 핵심 절차는 동일하게 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->