### PR TITLE
refactor(challenge): challenge 엔티티가 캐싱되지 않던 문제 해결, dto를 캐싱

### DIFF
--- a/src/main/java/doritos/doriroom/challenge/service/ChallengeService.java
+++ b/src/main/java/doritos/doriroom/challenge/service/ChallengeService.java
@@ -136,6 +136,7 @@ public class ChallengeService {
             throw new ChallengeStatusException("이미 시작했거나 완료한 과제입니다.");
         }
         userChallenge.setStatus(ChallengeStatus.IN_PROGRESS); // 미시작 과제 -> 도전 중으로 변경
+        invalidateUserChallengeCache(user); // 기존 캐시 무효화
     }
 
     @Transactional
@@ -148,6 +149,7 @@ public class ChallengeService {
             throw new ChallengeStatusException("도전 중인 과제만 완료 처리할 수 있습니다.");
         }
         userChallenge.setStatus(ChallengeStatus.WAIT_REWARD); // 도전 중 -> 보상 대기 상태로 변경
+        invalidateUserChallengeCache(user); // 기존 캐시 무효화
     }
 
     /* 과제 진행도 관련 */
@@ -162,6 +164,8 @@ public class ChallengeService {
         Map<Long, UserChallenge> userChallenges = userChallengeRepository.findByUserAndChallengeInWithFetch(user, challenges).stream()
                 .collect(Collectors.toMap(uc -> uc.getChallenge().getId(), uc->uc));
 
+        boolean hasChanges = false; // 변경 사항 추적
+
         for (Challenge challenge : challenges) {
             UserChallenge userChallenge = userChallenges.get(challenge.getId()); // 유저의 특정 과제에 대한 상태 조회
 
@@ -174,12 +178,17 @@ public class ChallengeService {
                         .currentProgress(0)
                         .build();
                 userChallengeRepository.save(userChallenge);
+                hasChanges = true;
             }
 
             // 완료된 과제는 제외
             if (userChallenge.getStatus() == ChallengeStatus.COMPLETED) {
                 continue;
             }
+
+            // 이전 과제 진척도
+            ChallengeStatus previousStatus = userChallenge.getStatus();
+            int previousProgress = userChallenge.getCurrentProgress();
 
             // 현재 과제 진척도 값 (새로운 과제 진척도를 반영한 값)
             int currentProgress = userChallenge.getCurrentProgress() + count;
@@ -194,10 +203,16 @@ public class ChallengeService {
                 userChallenge.setStatus(ChallengeStatus.NOT_STARTED);
             }
 
-            // 변경이 발생한 경우에만 캐시 무효화
-            if (!userChallenges.isEmpty()) {
-                invalidateUserChallengeCache(user);
+            // 상태나 진행도가 변경된 경우 플래그 설정
+            if (previousStatus != userChallenge.getStatus() ||
+                    previousProgress != userChallenge.getCurrentProgress()) {
+                hasChanges = true;
             }
+        }
+
+        // 변경이 있었다면 캐시 무효화
+        if (hasChanges) {
+            invalidateUserChallengeCache(user);
         }
     }
 
@@ -210,6 +225,8 @@ public class ChallengeService {
         Map<Long, UserChallenge> userChallenges = userChallengeRepository.findByUserAndChallengeInWithFetch(user, challenges).stream()
                 .collect(Collectors.toMap(uc -> uc.getChallenge().getId(), uc->uc));
 
+        boolean hasChanges = false;
+
         for (Challenge challenge : challenges) {
             UserChallenge userChallenge = userChallenges.get(challenge.getId());
 
@@ -221,11 +238,16 @@ public class ChallengeService {
                         .currentProgress(0)
                         .build();
                 userChallengeRepository.save(userChallenge);
+                hasChanges = true;
             }
 
             if (userChallenge.getStatus() == ChallengeStatus.COMPLETED) {
                 continue;
             }
+
+            // 이전 과제 진척도
+            ChallengeStatus previousStatus = userChallenge.getStatus();
+            int previousProgress = userChallenge.getCurrentProgress();
 
             // totalCount를 받아 진행도에 반영
             userChallenge.setCurrentProgress(totalCount);
@@ -237,9 +259,15 @@ public class ChallengeService {
                 userChallenge.setStatus(ChallengeStatus.IN_PROGRESS);
             }
 
-            if (!userChallenges.isEmpty()) {
-                invalidateUserChallengeCache(user);
+
+            if (previousStatus != userChallenge.getStatus() ||
+                    previousProgress != userChallenge.getCurrentProgress()) {
+                hasChanges = true;
             }
+        }
+
+        if (hasChanges) {
+            invalidateUserChallengeCache(user);
         }
     }
 

--- a/src/main/java/doritos/doriroom/challenge/service/ChallengeService.java
+++ b/src/main/java/doritos/doriroom/challenge/service/ChallengeService.java
@@ -49,36 +49,35 @@ public class ChallengeService {
 
     @Transactional(readOnly = true)
     public List<ChallengeResponseDto> getChallengesByGroup(User user, ChallengeGroup challengeGroup, AreaGroup areaGroup){
-        // 그룹별로 사용할 캐시 키 정의
-        String cacheKeyByGroup = RedisCacheService.CHALLENGES_KEY + challengeGroup + (areaGroup != null ? ":" + areaGroup : "");
+        // 캐시 키 정의
+        String cacheKey = RedisCacheService.CHALLENGES_KEY + user.getUserId().toString() + ":" +
+                challengeGroup.name() + (areaGroup != null ? "_" + areaGroup.name() : "");
 
-        // 캐시에서 조회
-        Optional<List<Challenge>> cachedChallenges = redisCacheService.getCacheList(
-                cacheKeyByGroup, new TypeReference<List<Challenge>>() {});
+        // 캐시에서 dto 조회
+        Optional<List<ChallengeResponseDto>> cachedDtoList = redisCacheService.getCacheList(
+                cacheKey, new TypeReference<>() {});
 
-        List<Challenge> challenges;
-        if (cachedChallenges.isPresent()) { // 캐시에 있으면 가져옴
-            challenges = cachedChallenges.get();
-        } else {
-            challenges = challengeFilterByGroup(challengeGroup, areaGroup); // 없으면 db에서 조회
-            redisCacheService.setCache(cacheKeyByGroup, challenges, RedisCacheService.CHALLENGES_TTL); // 캐시에 저장해둠
+        if (cachedDtoList.isPresent()) { // 캐시에 있으면 가져옴
+            return cachedDtoList.get();
         }
 
-        if (challenges.isEmpty()) {
-            return List.of();
-        }
+        List<Challenge> challenges = challengeFilterByGroup(challengeGroup, areaGroup); // 없으면 db에서 조회
 
         // 과제들에 대한 유저의 과제 상태 리스트 -> Map으로 변환
         Map<Long, UserChallenge> userChallengeMap = userChallengeRepository.findByUserAndChallengeInWithFetch(user, challenges).stream()
                 .collect(Collectors.toMap(uc -> uc.getChallenge().getId(), uc -> uc));
 
         // 도전과제 정보와 유저의 진행 상태를 반영하여 반환
-        return challenges.stream()
-            .map(challenge -> {
-                UserChallenge userProgress = userChallengeMap.get(challenge.getId());
-                return ChallengeResponseDto.of(challenge, userProgress);
-            })
-            .collect(Collectors.toList());
+        List<ChallengeResponseDto> challengeDtos = challenges.stream()
+                .map(challenge -> {
+                    UserChallenge userProgress = userChallengeMap.get(challenge.getId());
+                    return ChallengeResponseDto.of(challenge, userProgress);
+                })
+                .collect(Collectors.toList());
+
+        redisCacheService.setCache(cacheKey, challengeDtos, RedisCacheService.CHALLENGES_TTL); // 캐시에 저장해둠
+
+        return challengeDtos;
     }
 
     @Transactional

--- a/src/main/java/doritos/doriroom/challenge/service/ChallengeService.java
+++ b/src/main/java/doritos/doriroom/challenge/service/ChallengeService.java
@@ -111,6 +111,7 @@ public class ChallengeService {
         });
 
         userChallenge.setStatus(ChallengeStatus.COMPLETED); // 완료 상태로 변경
+        invalidateUserChallengeCache(user); // 과제 상태 변경되었으므로 기존 도전과제 캐싱 무효화
     }
 
     @Transactional
@@ -193,6 +194,10 @@ public class ChallengeService {
                 userChallenge.setStatus(ChallengeStatus.NOT_STARTED);
             }
 
+            // 변경이 발생한 경우에만 캐시 무효화
+            if (!userChallenges.isEmpty()) {
+                invalidateUserChallengeCache(user);
+            }
         }
     }
 
@@ -232,6 +237,9 @@ public class ChallengeService {
                 userChallenge.setStatus(ChallengeStatus.IN_PROGRESS);
             }
 
+            if (!userChallenges.isEmpty()) {
+                invalidateUserChallengeCache(user);
+            }
         }
     }
 
@@ -260,4 +268,11 @@ public class ChallengeService {
             throw new ChallengeStatusException("수동으로 시작할 수 없는 타입의 과제입니다.");
         }
     }
+
+    private void invalidateUserChallengeCache(User user) {
+        // 특정 유저의 모든 도전과제 캐시 삭제
+        String pattern = RedisCacheService.CHALLENGES_KEY + user.getUserId().toString() + ":*";
+        redisCacheService.deleteCache(pattern);
+    }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#160 

## 📝작업 내용

도전과제 엔티티의 polygon 필드의 텍스트 용량이 커서 캐싱되지 않던 문제를 해결했습니다.
Challenge 엔티티가 아닌 ChallengeResponseDto를 캐싱하도록 변경했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 버그 수정
  * 사용자별 캐시 키 적용으로 교차 사용자 데이터 반환 문제를 방지했습니다.
  * 보상 수령 및 진행 변경 시 관련 캐시를 무효화하여 최신 상태가 즉시 반영되도록 했습니다.

* 리팩터
  * 캐시 저장 형식을 엔터티에서 응답 DTO 중심으로 통일해 조회 및 반환 흐름을 단순화했습니다.
  * 캐시 히트 시 변환 없이 DTO를 직접 반환해 응답 성능을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->