### PR TITLE
feat(notifi): 알림 발송 테스트 API 추가

### DIFF
--- a/src/main/java/doritos/doriroom/notification/controller/NotificationController.java
+++ b/src/main/java/doritos/doriroom/notification/controller/NotificationController.java
@@ -1,6 +1,7 @@
-package doritos.doriroom.notification;
+package doritos.doriroom.notification.controller;
 
 import doritos.doriroom.global.dto.ApiResponse;
+import doritos.doriroom.notification.domain.NotificationType;
 import doritos.doriroom.notification.dto.NotificationResponseDto;
 import doritos.doriroom.notification.service.NotificationService;
 import doritos.doriroom.user.domain.User;
@@ -11,6 +12,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
 
 @RestController
 @RequestMapping("/api/notifications")
@@ -30,6 +32,11 @@ public class NotificationController {
                                               @Parameter(description = "읽음 처리할 알림의 ID")
                                               @PathVariable Long notificationId) {
         notificationService.markAsRead(user, notificationId);
+        return ApiResponse.ok();
+    }
+
+    public ApiResponse<Void> testNotification(@AuthenticationPrincipal User user){
+        notificationService.sendNotification(user, NotificationType.TEST_MESSAGE, "");
         return ApiResponse.ok();
     }
 }

--- a/src/main/java/doritos/doriroom/notification/controller/NotificationController.java
+++ b/src/main/java/doritos/doriroom/notification/controller/NotificationController.java
@@ -35,6 +35,8 @@ public class NotificationController {
         return ApiResponse.ok();
     }
 
+    @Operation(summary = "알림 발송 테스트")
+    @PostMapping("/test")
     public ApiResponse<Void> testNotification(@AuthenticationPrincipal User user){
         notificationService.sendNotification(user, NotificationType.TEST_MESSAGE, "");
         return ApiResponse.ok();

--- a/src/main/java/doritos/doriroom/notification/domain/NotificationType.java
+++ b/src/main/java/doritos/doriroom/notification/domain/NotificationType.java
@@ -8,7 +8,9 @@ public enum NotificationType {
     FOLLOWER("%s님이 회원님을 팔로우하기 시작했습니다."),
     GUESTBOOK_ENTRY("%s님이 방명록을 남겼습니다."),
     CHALLENGE_REWARD("도전과제 '%s'를 완료했습니다! 보상을 받아주세요."),
-    DIARY_LIKE("%s님이 회원님의 일기를 좋아합니다.");
+    DIARY_LIKE("%s님이 회원님의 일기를 좋아합니다."),
+
+    TEST_MESSAGE("테스트 메세지 발송!");
 
     private final String message;
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#165 

## 📝작업 내용
알림 발송 테스트 API를 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 테스트 알림 발송용 공개 엔드포인트가 추가되어 관리자가 또는 사용자가 직접 알림 수신을 확인할 수 있습니다.
  * 새로운 알림 유형이 도입되어 테스트 알림에 “테스트 메세지 발송!” 문구가 표시됩니다.
  * 점검 및 설정 확인 용도로 외부 호출하여 알림 동작을 검증할 수 있습니다.
  * 기존 알림 흐름과 동작에는 영향이 없습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->