### PR TITLE
fix: 지역별 랭킹 조회시 dense rank 적용

### DIFF
--- a/src/main/java/doritos/doriroom/ranking/repository/RankingRepository.java
+++ b/src/main/java/doritos/doriroom/ranking/repository/RankingRepository.java
@@ -48,8 +48,8 @@ public interface RankingRepository extends JpaRepository<User, UUID> {
         FROM UserAtlas ua
         JOIN ua.user u
         WHERE ua.atlas.areaGroup = :areaGroup
-          AND (ua.level > :myLevel OR (ua.level = :myLevel AND ua.currentExp > :myExp)
-          AND u.isWithdraw = false)
+        AND (ua.level > :myLevel OR (ua.level = :myLevel AND ua.currentExp > :myExp))
+        AND u.isWithdraw = false
         """)
     Long findMyRankByScore(@Param("areaGroup") AreaGroup areaGroup,
         @Param("myLevel") Integer myLevel,

--- a/src/main/java/doritos/doriroom/ranking/service/RankingService.java
+++ b/src/main/java/doritos/doriroom/ranking/service/RankingService.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -324,13 +325,12 @@ public class RankingService {
         Integer previousLevel = null;
         Long previousExp = null;
 
-        for (int i = 0; i < topUsers.size(); i++) {
-            UserAtlas userAtlas = topUsers.get(i);
-
+        for (UserAtlas userAtlas : topUsers) {
             // dense_rank 로직
             if (previousLevel != null && previousExp != null &&
-                (userAtlas.getLevel() != previousLevel || !userAtlas.getCurrentExp().equals(previousExp))) {
-                currentRank = i + 1;
+                (userAtlas.getLevel() != previousLevel || !userAtlas.getCurrentExp()
+                    .equals(previousExp))) {
+                currentRank++;
             }
 
             regionalUserRankMap.put(userAtlas.getUser().getUserId(), currentRank);
@@ -539,7 +539,7 @@ public class RankingService {
             // dense_rank 로직: 이전 점수와 다르면 현재 순위, 같으면 이전 순위 유지
             long score = scoresInOrder.get(i);
             if (previousScore != null && score != previousScore) {
-                currentRank = i + 1;
+                currentRank++;
             }
             previousScore = score;
             String rankDisplay = score == 0 ? "-" : String.valueOf(currentRank);
@@ -709,12 +709,27 @@ public class RankingService {
     }
 
     private String calculateRegionalDenseRank(String redisKey, long userScore) {
-        Long higherScoreCount = zSetOperations.count(redisKey, userScore + 1, Double.POSITIVE_INFINITY);
+        Set<ZSetOperations.TypedTuple<Object>> allScores = zSetOperations.reverseRangeWithScores(
+            redisKey, 0, -1);
 
-        if (higherScoreCount == null) {
-            return "-";
+        if (allScores == null || allScores.isEmpty()) {
+            return "1"; // 데이터가 없으면 1위
         }
 
-        return String.valueOf(higherScoreCount + 1);
+        // 점수별로 그룹화하여 dense_rank 계산
+        Map<Double, Long> scoreCounts = allScores.stream()
+            .filter(tuple -> tuple.getScore() != null)
+            .collect(Collectors.groupingBy(
+                TypedTuple::getScore,
+                Collectors.counting()
+            ));
+
+        // 사용자 점수보다 높은 점수들의 개수 계산
+        long higherScoreTypes = scoreCounts.entrySet().stream()
+            .filter(entry -> entry.getKey() > userScore)
+            .count();
+
+        // dense_rank = 더 높은 점수 종류의 개수 + 1
+        return String.valueOf(higherScoreTypes + 1);
     }
 } 

--- a/src/main/java/doritos/doriroom/ranking/service/RankingService.java
+++ b/src/main/java/doritos/doriroom/ranking/service/RankingService.java
@@ -132,9 +132,10 @@ public class RankingService {
         int atlasExp = (int) (totalScore % 10000);
 
         List<EquippedItemResponse> equippedItems = itemService.getOtherUserEquippedItems(currentUser.getUserId());
+        String rankDisplay = calculateRegionalDenseRank(redisKey, totalScore);
 
         return RegionalRankingResponseDto.builder()
-            .rank(rank == 0 ? "1" : String.valueOf(rank + 1))
+            .rank(rankDisplay)
             .userId(currentUser.getUserId())
             .nickname(currentUser.getNickname())
             .speech(currentUser.getSpeechBubble())
@@ -319,9 +320,22 @@ public class RankingService {
 
         // 지역별 참여한 사용자들의 ID와 순위 매핑
         Map<UUID, Integer> regionalUserRankMap = new HashMap<>();
+        int currentRank = 1;
+        Integer previousLevel = null;
+        Long previousExp = null;
+
         for (int i = 0; i < topUsers.size(); i++) {
             UserAtlas userAtlas = topUsers.get(i);
-            regionalUserRankMap.put(userAtlas.getUser().getUserId(), i + 1);
+
+            // dense_rank 로직
+            if (previousLevel != null && previousExp != null &&
+                (userAtlas.getLevel() != previousLevel || !userAtlas.getCurrentExp().equals(previousExp))) {
+                currentRank = i + 1;
+            }
+
+            regionalUserRankMap.put(userAtlas.getUser().getUserId(), currentRank);
+            previousLevel = userAtlas.getLevel();
+            previousExp = userAtlas.getCurrentExp();
         }
 
         // 전체 사용자 ID 수집
@@ -564,8 +578,20 @@ public class RankingService {
 
         // 지역별 참여한 사용자들의 ID와 순위 매핑
         Map<UUID, Integer> regionalUserRankMap = new HashMap<>();
+        int currentRank = 1;
+        Long previousScore = null;
+
         for (int i = 0; i < userIdsInOrder.size(); i++) {
-            regionalUserRankMap.put(userIdsInOrder.get(i), i + 1);
+            UUID userId = userIdsInOrder.get(i);
+            long score = scoresInOrder.get(i);
+
+            // dense_rank 로직
+            if (previousScore != null && score != previousScore) {
+                currentRank = i + 1;
+            }
+
+            regionalUserRankMap.put(userId, currentRank);
+            previousScore = score;
         }
 
         // 전체 사용자 ID 수집
@@ -608,7 +634,8 @@ public class RankingService {
             List<EquippedItemResponse> equippedItems = equippedItemsMap.getOrDefault(userId, List.of());
 
             // 참여한 사용자는 실제 순위 표시
-            String rankDisplay = String.valueOf(i + 1);
+            Integer regionalRank = regionalUserRankMap.get(userId);
+            String rankDisplay = String.valueOf(regionalRank);
 
             // Redis score에서 도감 레벨과 경험치 역계산
             long score = scoresInOrder.get(i);
@@ -679,5 +706,15 @@ public class RankingService {
             double score = userAtlas.getLevel() * 10000.0 + userAtlas.getCurrentExp();
             zSetOperations.add(redisKey, userAtlas.getUser().getUserId().toString(), score);
         }
+    }
+
+    private String calculateRegionalDenseRank(String redisKey, long userScore) {
+        Long higherScoreCount = zSetOperations.count(redisKey, userScore + 1, Double.POSITIVE_INFINITY);
+
+        if (higherScoreCount == null) {
+            return "-";
+        }
+
+        return String.valueOf(higherScoreCount + 1);
     }
 } 


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#156 

## 📝작업 내용

지역별 랭킹 조회 시 dense_rank를 적용했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 지역·전체 랭킹에 동순위(dense-rank) 적용: 동일 점수는 동일 순위로 표시합니다.
  - 마이 랭킹과 목록의 순위 표기를 일관화했습니다.
  - 미참가·점수 없음 사용자는 순위를 “-”로 표시합니다.

- Bug Fixes
  - 탈퇴(Withdraw) 사용자 처리 로직을 정교화해 랭킹 반영 정확도를 개선했습니다.
  - Redis와 MySQL 간 순위 표기 불일치 문제를 줄였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->