### PR TITLE
Featrue/169 notification

### DIFF
--- a/src/main/java/doritos/doriroom/challenge/controller/ChallengeController.java
+++ b/src/main/java/doritos/doriroom/challenge/controller/ChallengeController.java
@@ -33,6 +33,14 @@ public class ChallengeController {
         return ApiResponse.ok(challengeService.getChallengesByGroup(user, challengeGroup, areaGroup));
     }
 
+    @GetMapping("/{challengeId}")
+    @Operation(summary = "도전과제 상세 정보 조회")
+    public ApiResponse<ChallengeResponseDto> getChallengeDetail(@AuthenticationPrincipal User user,
+                                                                @Parameter(description = "조회할 도전과제의 ID")
+                                                                @PathVariable Long challengeId) {
+        return ApiResponse.ok(challengeService.getChallengeDetail(user, challengeId));
+    }
+
     @PostMapping("/{challengeId}/claim") // 해당 도전과제의 보상 받기 처리
     @Operation(summary = "특정 도전과제의 보상 받기 처리", description = "challengeId로 관련 리워드를 사용자에게 지급 및 도전과제 상태를 완료로 처리")
     public ApiResponse<Void> claimChallengeReward(@AuthenticationPrincipal User user,

--- a/src/main/java/doritos/doriroom/challenge/service/ChallengeService.java
+++ b/src/main/java/doritos/doriroom/challenge/service/ChallengeService.java
@@ -83,6 +83,17 @@ public class ChallengeService {
         return challengeDtos;
     }
 
+    @Transactional(readOnly = true)
+    public ChallengeResponseDto getChallengeDetail(User user, Long challengeId) {
+        Challenge challenge = challengeRepository.findById(challengeId)
+                .orElseThrow(ChallengeNotFoundException::new);
+
+        UserChallenge userProgress = userChallengeRepository.findByUserAndChallenge(user, challenge)
+                .orElse(null); // 진행도가 없으면 null
+
+        return ChallengeResponseDto.of(challenge, userProgress);
+    }
+
     @Transactional
     public void claimChallengeReward(User user, Long challengeId){
         Challenge challenge = challengeRepository.findById(challengeId)
@@ -202,7 +213,7 @@ public class ChallengeService {
                 userChallenge.setStatus(ChallengeStatus.WAIT_REWARD); // 현재 진척도가 TargetCount보다 크면 보상 대기
 
                 if (previousStatus != ChallengeStatus.WAIT_REWARD) { // 최초 보상 수령 가능 시 알람 전송
-                    notificationService.sendNotification(user, NotificationType.CHALLENGE_REWARD, challenge.getTitle());
+                    notificationService.sendNotification(user, NotificationType.CHALLENGE_REWARD, challenge.getTitle(), challenge.getId().toString());
                 }
             } else if (currentProgress > 0){ // TargetCount보다 작으면 IN_PROGRESS로 변경 (보상 받지 않았는데 이후 진척도가 줄면 재달성 요구함)
                 userChallenge.setStatus(ChallengeStatus.IN_PROGRESS);
@@ -262,7 +273,7 @@ public class ChallengeService {
                 userChallenge.setStatus(ChallengeStatus.WAIT_REWARD);
 
                 if (previousStatus != ChallengeStatus.WAIT_REWARD) { // 최초 보상 수령 가능 시 알람 전송
-                    notificationService.sendNotification(user, NotificationType.CHALLENGE_REWARD, challenge.getTitle());
+                    notificationService.sendNotification(user, NotificationType.CHALLENGE_REWARD, challenge.getTitle(), challenge.getId().toString());
                 }
             } else if (totalCount == 0){
                 userChallenge.setStatus(ChallengeStatus.NOT_STARTED);

--- a/src/main/java/doritos/doriroom/diary/service/DiaryLikeService.java
+++ b/src/main/java/doritos/doriroom/diary/service/DiaryLikeService.java
@@ -48,7 +48,7 @@ public class DiaryLikeService {
                     diaryRepository.save(diary);
 
                     // 일기 주인에게 좋아요 알림 발송
-                    notificationService.sendNotification(diaryOwner, NotificationType.DIARY_LIKE, user.getNickname());
+                    notificationService.sendNotification(diaryOwner, NotificationType.DIARY_LIKE, user.getNickname(), diary.getDiaryId().toString());
 
                     return true;
                 }

--- a/src/main/java/doritos/doriroom/follow/service/FollowService.java
+++ b/src/main/java/doritos/doriroom/follow/service/FollowService.java
@@ -66,7 +66,7 @@ public class FollowService {
         challengeService.updateChallengeProgressCount(user, ChallengeType.REACH_NEIGHBOR_COUNT, currentFollowingCount);
 
         // 타겟 유저에게 알림 전송
-        notificationService.sendNotification(targetUser, NotificationType.FOLLOWER, user.getNickname());
+        notificationService.sendNotification(targetUser, NotificationType.FOLLOWER, user.getNickname(), user.getUserId().toString());
 
         return FollowResponseDto.from(follow);
     }

--- a/src/main/java/doritos/doriroom/guestbook/service/GuestbookService.java
+++ b/src/main/java/doritos/doriroom/guestbook/service/GuestbookService.java
@@ -51,7 +51,7 @@ public class GuestbookService {
         Guestbook savedGuestbook = guestbookRepository.save(guestbook);
 
         // 방 주인에게 방명록 작성 알림 발송
-        notificationService.sendNotification(roomOwner, NotificationType.GUESTBOOK_ENTRY, user.getNickname());
+        notificationService.sendNotification(roomOwner, NotificationType.GUESTBOOK_ENTRY, user.getNickname(), roomOwner.getUserId().toString());
 
         return GuestbookResponseDto.from(savedGuestbook, user.getNickname(), equippedItems);
     }

--- a/src/main/java/doritos/doriroom/notification/controller/NotificationController.java
+++ b/src/main/java/doritos/doriroom/notification/controller/NotificationController.java
@@ -2,6 +2,7 @@ package doritos.doriroom.notification.controller;
 
 import doritos.doriroom.global.dto.ApiResponse;
 import doritos.doriroom.notification.domain.NotificationType;
+import doritos.doriroom.notification.dto.NotificationRedirectDto;
 import doritos.doriroom.notification.dto.NotificationResponseDto;
 import doritos.doriroom.notification.service.NotificationService;
 import doritos.doriroom.user.domain.User;
@@ -26,19 +27,18 @@ public class NotificationController {
         return ApiResponse.ok(notificationService.getMyNotifications(user, pageable));
     }
 
-    @Operation(summary = "특정 알림 읽음 처리")
+    @Operation(summary = "특정 알림 읽음 처리 및 알림 관련 페이지로 이동")
     @PostMapping("/{notificationId}/read")
-    public ApiResponse<Void> readNotification(@AuthenticationPrincipal User user,
-                                              @Parameter(description = "읽음 처리할 알림의 ID")
-                                              @PathVariable Long notificationId) {
-        notificationService.markAsRead(user, notificationId);
-        return ApiResponse.ok();
+    public ApiResponse<NotificationRedirectDto> readAndRedirect(@AuthenticationPrincipal User user,
+                                                                @Parameter(description = "처리할 알림의 ID")
+                                                                @PathVariable Long notificationId) {
+        return ApiResponse.ok(notificationService.readAndRedirect(user, notificationId));
     }
 
     @Operation(summary = "알림 발송 테스트")
     @PostMapping("/test")
     public ApiResponse<Void> testNotification(@AuthenticationPrincipal User user){
-        notificationService.sendNotification(user, NotificationType.TEST_MESSAGE, "");
+        notificationService.sendNotification(user, NotificationType.TEST_MESSAGE, "", "");
         return ApiResponse.ok();
     }
 }

--- a/src/main/java/doritos/doriroom/notification/domain/Notification.java
+++ b/src/main/java/doritos/doriroom/notification/domain/Notification.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "notifications")
-@Getter
+@Getter @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor
 @Builder
 public class Notification {

--- a/src/main/java/doritos/doriroom/notification/domain/Notification.java
+++ b/src/main/java/doritos/doriroom/notification/domain/Notification.java
@@ -28,6 +28,9 @@ public class Notification {
     @Column(nullable = false)
     private NotificationType type; // 알림 타입
 
+    @Column(length = 36)
+    private String targetId; // 페이지 이동 Id, UUID | Long
+
     @Builder.Default
     @Column(name = "is_read", nullable = false)
     private boolean read = false; // 알림 읽음 여부

--- a/src/main/java/doritos/doriroom/notification/domain/Notification.java
+++ b/src/main/java/doritos/doriroom/notification/domain/Notification.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "notifications")
-@Getter @Setter
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor
 @Builder
 public class Notification {

--- a/src/main/java/doritos/doriroom/notification/dto/NotificationRedirectDto.java
+++ b/src/main/java/doritos/doriroom/notification/dto/NotificationRedirectDto.java
@@ -1,0 +1,9 @@
+package doritos.doriroom.notification.dto;
+
+public record NotificationRedirectDto(
+        String redirectUrl
+) {
+    public static NotificationRedirectDto of(String redirectUrl) {
+        return new NotificationRedirectDto(redirectUrl);
+    }
+}

--- a/src/main/java/doritos/doriroom/notification/repository/NotificationRepository.java
+++ b/src/main/java/doritos/doriroom/notification/repository/NotificationRepository.java
@@ -9,8 +9,6 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     Page<Notification> findByUserOrderByCreatedAtDesc(User user, Pageable pageable); // 알림 목록을 최신순으로 페이징
 

--- a/src/main/java/doritos/doriroom/notification/repository/NotificationRepository.java
+++ b/src/main/java/doritos/doriroom/notification/repository/NotificationRepository.java
@@ -5,10 +5,16 @@ import doritos.doriroom.user.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     Page<Notification> findByUserOrderByCreatedAtDesc(User user, Pageable pageable); // 알림 목록을 최신순으로 페이징
-    List<Notification> findByUserAndReadFalse(User user);
+
+    @Modifying // 한 번에 read 필드를 true로 변경
+    @Query("UPDATE Notification n SET n.read = true WHERE n.user = :user AND n.read = false")
+    void markAllAsReadByUser(@Param("user") User user);
 }

--- a/src/main/java/doritos/doriroom/notification/repository/NotificationRepository.java
+++ b/src/main/java/doritos/doriroom/notification/repository/NotificationRepository.java
@@ -6,8 +6,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.UUID;
+import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     Page<Notification> findByUserOrderByCreatedAtDesc(User user, Pageable pageable); // 알림 목록을 최신순으로 페이징
+    List<Notification> findByUserAndReadFalse(User user);
 }

--- a/src/main/java/doritos/doriroom/notification/service/NotificationService.java
+++ b/src/main/java/doritos/doriroom/notification/service/NotificationService.java
@@ -10,6 +10,7 @@ import doritos.doriroom.notification.exception.AccessDeniedException;
 import doritos.doriroom.notification.exception.NotificationNotFoundException;
 import doritos.doriroom.notification.repository.NotificationRepository;
 import doritos.doriroom.user.domain.User;
+import doritos.doriroom.user.repository.UserRepository;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -19,10 +20,13 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class NotificationService {
+    private final UserRepository userRepository;
     private final NotificationRepository notificationRepository;
 
     // 푸시 알림 전송
@@ -67,9 +71,16 @@ public class NotificationService {
     }
 
     // 알림 목록 조회
-    @Transactional(readOnly = true)
+    @Transactional
     public Page<NotificationResponseDto> getMyNotifications(User user, Pageable pageable) {
         Page<Notification> notifications = notificationRepository.findByUserOrderByCreatedAtDesc(user, pageable);
+
+        // 안 읽은 상태의 알림 리스트
+        List<Notification> unreadNotifications = notificationRepository.findByUserAndReadFalse(user);
+        for (Notification notification : unreadNotifications) {
+            notification.markAsRead();
+        }
+
         return notifications.map(NotificationResponseDto::from);
     }
 

--- a/src/main/java/doritos/doriroom/notification/service/NotificationService.java
+++ b/src/main/java/doritos/doriroom/notification/service/NotificationService.java
@@ -11,7 +11,6 @@ import doritos.doriroom.notification.exception.AccessDeniedException;
 import doritos.doriroom.notification.exception.NotificationNotFoundException;
 import doritos.doriroom.notification.repository.NotificationRepository;
 import doritos.doriroom.user.domain.User;
-import doritos.doriroom.user.repository.UserRepository;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -27,7 +26,6 @@ import java.util.List;
 @RequiredArgsConstructor
 @Slf4j
 public class NotificationService {
-    private final UserRepository userRepository;
     private final NotificationRepository notificationRepository;
 
     // 푸시 알림 전송
@@ -100,12 +98,17 @@ public class NotificationService {
             notification.markAsRead(); // 안 읽은 상태인 경우 -> 읽음 상태로 변경
         }
 
+        String targetId = notification.getTargetId();
+        if (targetId == null || targetId.isBlank()) {
+            return NotificationRedirectDto.of("/");
+        }
+
         String redirectUrl = switch (notification.getType()) {
-            case DIARY_LIKE        -> "/api/diary/" + notification.getTargetId(); // diaryId
-            case FOLLOWER      -> "/api/users/room/" + notification.getTargetId(); // userId
-            case CHALLENGE_REWARD  -> "/api/challenges/" + notification.getTargetId(); // challengeId
-            case GUESTBOOK_ENTRY -> "/api/guestbooks/room/" + notification.getTargetId();  // roomOwnerId
-            default -> "/"; // 기본 경로는 홈
+            case DIARY_LIKE        -> "/api/diary/" + targetId; // diaryId
+            case FOLLOWER      -> "/api/users/room/" + targetId; // userId
+            case CHALLENGE_REWARD  -> "/api/challenges/" + targetId; // challengeId
+            case GUESTBOOK_ENTRY -> "/api/guestbooks/room/" + targetId;  // roomOwnerId
+            default -> "/";
         };
 
         return NotificationRedirectDto.of(redirectUrl);

--- a/src/main/java/doritos/doriroom/notification/service/NotificationService.java
+++ b/src/main/java/doritos/doriroom/notification/service/NotificationService.java
@@ -5,6 +5,7 @@ import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import doritos.doriroom.notification.domain.Notification;
 import doritos.doriroom.notification.domain.NotificationType;
+import doritos.doriroom.notification.dto.NotificationRedirectDto;
 import doritos.doriroom.notification.dto.NotificationResponseDto;
 import doritos.doriroom.notification.exception.AccessDeniedException;
 import doritos.doriroom.notification.exception.NotificationNotFoundException;
@@ -31,7 +32,7 @@ public class NotificationService {
 
     // 푸시 알림 전송
     @Transactional
-    public void sendNotification(User user, NotificationType type, String placeholder) {
+    public void sendNotification(User user, NotificationType type, String placeholder, String targetId) {
         String content = type.createContent(placeholder); // content 구성
 
         // db에 알림 내용 저장
@@ -39,6 +40,7 @@ public class NotificationService {
                 .user(user)
                 .content(content)
                 .type(type)
+                .targetId(targetId)
                 .build();
         notificationRepository.save(notification);
 
@@ -86,7 +88,7 @@ public class NotificationService {
 
     // 알림 읽음 처리
     @Transactional
-    public void markAsRead(User user, Long notificationId) {
+    public NotificationRedirectDto readAndRedirect(User user, Long notificationId) {
         Notification notification = notificationRepository.findById(notificationId)
                 .orElseThrow(NotificationNotFoundException::new);
 
@@ -94,6 +96,18 @@ public class NotificationService {
             throw new AccessDeniedException();
         }
 
-        notification.markAsRead(); //읽음 상태로 변경
+        if (!notification.isRead()) {
+            notification.markAsRead(); // 안 읽은 상태인 경우 -> 읽음 상태로 변경
+        }
+
+        String redirectUrl = switch (notification.getType()) {
+            case DIARY_LIKE        -> "/api/diary/" + notification.getTargetId(); // diaryId
+            case FOLLOWER      -> "/api/users/room/" + notification.getTargetId(); // userId
+            case CHALLENGE_REWARD  -> "/api/challenges/" + notification.getTargetId(); // challengeId
+            case GUESTBOOK_ENTRY -> "/api/guestbooks/room/" + notification.getTargetId();  // roomOwnerId
+            default -> "/"; // 기본 경로는 홈
+        };
+
+        return NotificationRedirectDto.of(redirectUrl);
     }
 }

--- a/src/main/java/doritos/doriroom/notification/service/NotificationService.java
+++ b/src/main/java/doritos/doriroom/notification/service/NotificationService.java
@@ -75,11 +75,7 @@ public class NotificationService {
     public Page<NotificationResponseDto> getMyNotifications(User user, Pageable pageable) {
         Page<Notification> notifications = notificationRepository.findByUserOrderByCreatedAtDesc(user, pageable);
 
-        // 안 읽은 상태의 알림 리스트
-        List<Notification> unreadNotifications = notificationRepository.findByUserAndReadFalse(user);
-        for (Notification notification : unreadNotifications) {
-            notification.markAsRead();
-        }
+        notificationRepository.markAllAsReadByUser(user);  // 안 읽은 상태의 알림을 읽음 처리
 
         return notifications.map(NotificationResponseDto::from);
     }


### PR DESCRIPTION
## #️⃣연관된 이슈
#169 

## 📝작업 내용

알림 목록 조회 시 읽지 않은 모든 알림에 대해 읽음 상태로 변환하도록 구현했습니다.

기존 sendNotification()를 수정했습니다.
- 알림 엔티티에 문자열 targetId 필드를 추가
- 알림 이벤트 발생 시 관련 Id를 엔티티에 저장

기존 특정 알림을 읽음 상태로 변경하는 api를 수정했습니다.
-> 읽음 처리 및 리다이렉트 URL 반환



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 특정 도전 과제의 상세 정보를 조회하는 API가 추가되었습니다.
  * 알림을 읽을 때 리다이렉트 URL을 함께 반환해 관련 화면으로 즉시 이동할 수 있습니다.
  * 좋아요/팔로우/방명록/도전 과제 관련 알림에 대상 ID가 포함되어 정확한 화면으로 연결됩니다.
  * 내 알림 목록 조회 시 미읽음 알림이 자동으로 읽음 처리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->