### PR TITLE
Fix/171 quiz

### DIFF
--- a/src/main/java/doritos/doriroom/challenge/service/ChallengeService.java
+++ b/src/main/java/doritos/doriroom/challenge/service/ChallengeService.java
@@ -23,8 +23,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -53,18 +56,23 @@ public class ChallengeService {
     @Transactional(readOnly = true)
     public List<ChallengeResponseDto> getChallengesByGroup(User user, ChallengeGroup challengeGroup, AreaGroup areaGroup){
         // 캐시 키 정의
-        String cacheKey = RedisCacheService.CHALLENGES_KEY + user.getUserId().toString() + ":" +
-                challengeGroup.name() + (areaGroup != null ? "_" + areaGroup.name() : "");
+        String userKey = RedisCacheService.CHALLENGES_KEY + user.getUserId().toString();
+        String groupKey = challengeGroup.name() + (areaGroup != null ? "_" + areaGroup.name() : "");
 
         // 캐시에서 dto 조회
-        Optional<List<ChallengeResponseDto>> cachedDtoList = redisCacheService.getCacheList(
-                cacheKey, new TypeReference<>() {});
+        Optional<Map<String, List<ChallengeResponseDto>>> cachedData =
+                redisCacheService.getCache(userKey, new TypeReference<Map<String, List<ChallengeResponseDto>>>() {});
 
-        if (cachedDtoList.isPresent()) { // 캐시에 있으면 가져옴
-            return cachedDtoList.get();
+        if (cachedData.isPresent()) { // 캐시에 있으면 가져옴
+            List<ChallengeResponseDto> groupData = cachedData.get().get(groupKey);
+            if (groupData != null) {
+                log.debug("캐시 히트 - 유저: {}, 그룹: {}", user.getUserId(), groupKey);
+                return groupData;
+            }
         }
 
-        List<Challenge> challenges = challengeFilterByGroup(challengeGroup, areaGroup); // 없으면 db에서 조회
+        log.debug("캐시 미스 - 유저: {}, 그룹: {}", user.getUserId(), groupKey);
+        List<Challenge> challenges = challengeFilterByGroup(challengeGroup, areaGroup);  // 없으면 db에서 조회
 
         // 과제들에 대한 유저의 과제 상태 리스트 -> Map으로 변환
         Map<Long, UserChallenge> userChallengeMap = userChallengeRepository.findByUserAndChallengeInWithFetch(user, challenges).stream()
@@ -78,7 +86,10 @@ public class ChallengeService {
                 })
                 .collect(Collectors.toList());
 
-        redisCacheService.setCache(cacheKey, challengeDtos, RedisCacheService.CHALLENGES_TTL); // 캐시에 저장해둠
+        // 캐시 저장 (기존 데이터에 새 그룹 추가)
+        Map<String, List<ChallengeResponseDto>> allData = cachedData.orElseGet(HashMap::new);
+        allData.put(groupKey, challengeDtos);
+        redisCacheService.setCache(userKey, allData, RedisCacheService.CHALLENGES_TTL);
 
         return challengeDtos;
     }
@@ -125,7 +136,7 @@ public class ChallengeService {
         });
 
         userChallenge.setStatus(ChallengeStatus.COMPLETED); // 완료 상태로 변경
-        invalidateUserChallengeCache(user); // 과제 상태 변경되었으므로 기존 도전과제 캐싱 무효화
+        registerCacheInvalidation(user); // 과제 상태 변경되었으므로 기존 도전과제 캐싱 무효화
     }
 
     @Transactional
@@ -150,7 +161,7 @@ public class ChallengeService {
             throw new ChallengeStatusException("이미 시작했거나 완료한 과제입니다.");
         }
         userChallenge.setStatus(ChallengeStatus.IN_PROGRESS); // 미시작 과제 -> 도전 중으로 변경
-        invalidateUserChallengeCache(user); // 기존 캐시 무효화
+        registerCacheInvalidation(user); // 기존 캐시 무효화
     }
 
     @Transactional
@@ -163,7 +174,7 @@ public class ChallengeService {
             throw new ChallengeStatusException("도전 중인 과제만 완료 처리할 수 있습니다.");
         }
         userChallenge.setStatus(ChallengeStatus.WAIT_REWARD); // 도전 중 -> 보상 대기 상태로 변경
-        invalidateUserChallengeCache(user); // 기존 캐시 무효화
+        registerCacheInvalidation(user); // 기존 캐시 무효화
     }
 
     /* 과제 진행도 관련 */
@@ -230,7 +241,7 @@ public class ChallengeService {
 
         // 변경이 있었다면 캐시 무효화
         if (hasChanges) {
-            invalidateUserChallengeCache(user);
+            registerCacheInvalidation(user);
         }
     }
 
@@ -289,17 +300,37 @@ public class ChallengeService {
         }
 
         if (hasChanges) {
-            invalidateUserChallengeCache(user);
+            registerCacheInvalidation(user);
         }
     }
 
     public void invalidateUserChallengeCache(User user) {
         // 특정 유저의 모든 도전과제 캐시 삭제
-        String pattern = RedisCacheService.CHALLENGES_KEY + user.getUserId().toString() + ":*";
-        redisCacheService.deleteKeysByPattern(pattern);
+        try {
+            String cacheKey = RedisCacheService.CHALLENGES_KEY + user.getUserId().toString();
+            redisCacheService.deleteCache(cacheKey);
+
+            log.info("유저 {} 도전과제 캐시 삭제 완료", user.getUserId());
+        } catch (Exception e) {
+            log.error("캐시 삭제 실패 - 유저: {}", user.getUserId(), e);
+        }
     }
 
+
     /* 내부 메서드 */
+
+    // 트랜잭션 커밋 후 캐시 무효화
+    private void registerCacheInvalidation(User user) {
+        TransactionSynchronizationManager.registerSynchronization(
+                new TransactionSynchronization() {
+                    @Override
+                    public void afterCommit() {
+                        invalidateUserChallengeCache(user);
+                    }
+                }
+        );
+    }
+
     private List<Challenge> challengeFilterByGroup(ChallengeGroup challengeGroup, AreaGroup areaGroup){
         if(challengeGroup == null)  // challengeGroup은 필수 파라미터
             throw new ChallengeArgumentException("요청에 challengeGroup 값이 필요합니다.");

--- a/src/main/java/doritos/doriroom/challenge/service/ChallengeService.java
+++ b/src/main/java/doritos/doriroom/challenge/service/ChallengeService.java
@@ -293,6 +293,12 @@ public class ChallengeService {
         }
     }
 
+    public void invalidateUserChallengeCache(User user) {
+        // 특정 유저의 모든 도전과제 캐시 삭제
+        String pattern = RedisCacheService.CHALLENGES_KEY + user.getUserId().toString() + ":*";
+        redisCacheService.deleteKeysByPattern(pattern);
+    }
+
     /* 내부 메서드 */
     private List<Challenge> challengeFilterByGroup(ChallengeGroup challengeGroup, AreaGroup areaGroup){
         if(challengeGroup == null)  // challengeGroup은 필수 파라미터
@@ -318,11 +324,4 @@ public class ChallengeService {
             throw new ChallengeStatusException("수동으로 시작할 수 없는 타입의 과제입니다.");
         }
     }
-
-    private void invalidateUserChallengeCache(User user) {
-        // 특정 유저의 모든 도전과제 캐시 삭제
-        String pattern = RedisCacheService.CHALLENGES_KEY + user.getUserId().toString() + ":*";
-        redisCacheService.deleteCache(pattern);
-    }
-
 }

--- a/src/main/java/doritos/doriroom/global/cache/RedisCacheService.java
+++ b/src/main/java/doritos/doriroom/global/cache/RedisCacheService.java
@@ -71,6 +71,19 @@ public class RedisCacheService {
         }
     }
 
+    // 패턴으로 캐시 삭제
+    public void deleteKeysByPattern(String pattern) {
+        try {
+            Set<String> keys = redisTemplate.keys(pattern);
+            if (keys != null && !keys.isEmpty()) {
+                redisTemplate.delete(keys);
+                log.info("패턴으로 캐시 삭제 성공: {}", pattern);
+            }
+        } catch (Exception e) {
+            log.error("패턴으로 캐시 삭제 실패: {}", pattern, e);
+        }
+    }
+
     // 모든 캐시 삭제 (관리자용)
     public void clearAllCaches() {
         try {

--- a/src/main/java/doritos/doriroom/global/cache/RedisCacheService.java
+++ b/src/main/java/doritos/doriroom/global/cache/RedisCacheService.java
@@ -60,6 +60,22 @@ public class RedisCacheService {
             return Optional.empty();
         }
     }
+    // 캐시 조회
+    public <T> Optional<T> getCache(String key, TypeReference<T> typeReference) {
+        try {
+            Object cachedData = redisTemplate.opsForValue().get(key);
+            if (cachedData != null) {
+                T result = objectMapper.readValue(cachedData.toString(), typeReference);
+                log.info("캐시 조회 성공: {}", key);
+                return Optional.of(result);
+            }
+            log.info("캐시 조회 정보 없음: {}", key);
+            return Optional.empty();
+        } catch (Exception e) {
+            log.error("캐시 조회 실패: {}", key, e);
+            return Optional.empty();
+        }
+    }
 
     // 캐시 삭제
     public void deleteCache(String key) {
@@ -68,19 +84,6 @@ public class RedisCacheService {
             log.info("캐시 삭제: {}", key);
         } catch (Exception e) {
             log.error("캐시 삭제 실패: {}", key, e);
-        }
-    }
-
-    // 패턴으로 캐시 삭제
-    public void deleteKeysByPattern(String pattern) {
-        try {
-            Set<String> keys = redisTemplate.keys(pattern);
-            if (keys != null && !keys.isEmpty()) {
-                redisTemplate.delete(keys);
-                log.info("패턴으로 캐시 삭제 성공: {}", pattern);
-            }
-        } catch (Exception e) {
-            log.error("패턴으로 캐시 삭제 실패: {}", pattern, e);
         }
     }
 

--- a/src/main/java/doritos/doriroom/quiz/service/QuizService.java
+++ b/src/main/java/doritos/doriroom/quiz/service/QuizService.java
@@ -19,7 +19,6 @@ import doritos.doriroom.quiz.exception.QuizNotFoundException;
 import doritos.doriroom.quiz.repository.QuestionRepository;
 import doritos.doriroom.quiz.repository.QuizRepository;
 import doritos.doriroom.user.domain.User;
-import doritos.doriroom.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/doritos/doriroom/quiz/service/QuizService.java
+++ b/src/main/java/doritos/doriroom/quiz/service/QuizService.java
@@ -23,6 +23,8 @@ import doritos.doriroom.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -62,7 +64,7 @@ public class QuizService {
         // 상태가 NOT_STARTED이면 IN_PROGRESS로 변경
         if (userChallenge.getStatus() == ChallengeStatus.NOT_STARTED) {
             userChallenge.setStatus(ChallengeStatus.IN_PROGRESS);
-            challengeService.invalidateUserChallengeCache(user);  // 상태 변경 시 캐시 초기화
+            registerCacheInvalidation(user);  // 상태 변경 시 캐시 초기화
         }
 
         // 해당 도전과제의 퀴즈를 불러옴
@@ -97,7 +99,7 @@ public class QuizService {
         }
 
         userChallenge.setStatus(ChallengeStatus.WAIT_REWARD); //  보상 대기 상태로 변경
-        challengeService.invalidateUserChallengeCache(user); // 상태 변경 후 캐시 초기화
+        registerCacheInvalidation(user); // 상태 변경 후 캐시 초기화
 
 
         // 도전과제의 보상 정보를 dto로 변환
@@ -106,6 +108,20 @@ public class QuizService {
                 .collect(Collectors.toList());
 
         return new QuizCompleteResponseDto(true, rewards);
+    }
+
+    /* 내부 메서드 */
+
+    // 트랜잭션 커밋 후 캐시 무효화
+    private void registerCacheInvalidation(User user) {
+        TransactionSynchronizationManager.registerSynchronization(
+                new TransactionSynchronization() {
+                    @Override
+                    public void afterCommit() {
+                        challengeService.invalidateUserChallengeCache(user);
+                    }
+                }
+        );
     }
 }
 

--- a/src/main/java/doritos/doriroom/quiz/service/QuizService.java
+++ b/src/main/java/doritos/doriroom/quiz/service/QuizService.java
@@ -8,6 +8,7 @@ import doritos.doriroom.challenge.exception.ChallengeNotFoundException;
 import doritos.doriroom.challenge.exception.ChallengeStatusException;
 import doritos.doriroom.challenge.repository.ChallengeRepository;
 import doritos.doriroom.challenge.repository.UserChallengeRepository;
+import doritos.doriroom.challenge.service.ChallengeService;
 import doritos.doriroom.quiz.domain.Question;
 import doritos.doriroom.quiz.domain.Quiz;
 import doritos.doriroom.quiz.dto.request.QuestionSubmitRequestDto;
@@ -18,6 +19,7 @@ import doritos.doriroom.quiz.exception.QuizNotFoundException;
 import doritos.doriroom.quiz.repository.QuestionRepository;
 import doritos.doriroom.quiz.repository.QuizRepository;
 import doritos.doriroom.user.domain.User;
+import doritos.doriroom.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,6 +34,7 @@ public class QuizService {
     private final ChallengeRepository challengeRepository;
     private final UserChallengeRepository userChallengeRepository;
     private final QuestionRepository questionRepository;
+    private final ChallengeService challengeService;
 
 
     @Transactional
@@ -59,6 +62,7 @@ public class QuizService {
         // 상태가 NOT_STARTED이면 IN_PROGRESS로 변경
         if (userChallenge.getStatus() == ChallengeStatus.NOT_STARTED) {
             userChallenge.setStatus(ChallengeStatus.IN_PROGRESS);
+            challengeService.invalidateUserChallengeCache(user);  // 상태 변경 시 캐시 초기화
         }
 
         // 해당 도전과제의 퀴즈를 불러옴
@@ -92,8 +96,8 @@ public class QuizService {
             throw new ChallengeStatusException("이미 완료했거나 보상 대기 중인 과제입니다.");
         }
 
-        //  보상 대기 상태로 변경
-        userChallenge.setStatus(ChallengeStatus.WAIT_REWARD);
+        userChallenge.setStatus(ChallengeStatus.WAIT_REWARD); //  보상 대기 상태로 변경
+        challengeService.invalidateUserChallengeCache(user); // 상태 변경 후 캐시 초기화
 
 
         // 도전과제의 보상 정보를 dto로 변환


### PR DESCRIPTION
## #️⃣연관된 이슈

#171 

## 📝작업 내용

퀴즈 도전과제를 수행하여 상태가 WAIR_REWARD로 변경 되어야하는 상황에서 NOT_STARTED로 조회되던 이슈를 해결했습니다.

원인: 다른 과제와 달리, 퀴즈 도전과제 상태 변경 시 캐시 무효화를 적용하지 않았음.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 버그 수정
  * 퀴즈 시작/완료 시 사용자 도전과제 캐시가 즉시 반영되지 않던 문제를 개선해 최신 진행 상태가 지연 없이 표시됩니다.
  * 도전과제 진행도 및 보상 대기 상태(배지, 카운트 등) 불일치 현상을 완화했습니다.

* 리팩터링
  * 사용자별(유저+그룹) 도전과제 캐시 구조를 개선하고 트랜잭션 커밋 후 무효화 등록 방식으로 안정성을 높였습니다.
  * 퀴즈 상태 전환 경로에 일관된 캐시 무효화 흐름을 적용했습니다.

* 기타
  * 캐시 조회 로깅 및 단일 객체 조회 지원이 추가되어 캐시 동작 가시성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->