### PR TITLE
Bug/173 qa

### DIFF
--- a/src/main/java/doritos/doriroom/auth/dto/request/SignupRequestDto.java
+++ b/src/main/java/doritos/doriroom/auth/dto/request/SignupRequestDto.java
@@ -11,9 +11,9 @@ public record SignupRequestDto (
         @Schema(description = "로그인 아이디(소문자+숫자, 4~20자)", example = "user1234")
         @NotBlank String username,
 
-        @Pattern(regexp = "^(?=.{8,20}$)((?=.*[a-zA-Z])(?=.*\\d)|(?=.*[a-zA-Z])(?=.*[!@#$%^&*])|(?=.*\\d)(?=.*[!@#$%^&*])).*$",
+        @Pattern(regexp = "^(?=.{6,20}$)((?=.*[a-zA-Z])(?=.*\\d)|(?=.*[a-zA-Z])(?=.*[!@#$%^&*])|(?=.*\\d)(?=.*[!@#$%^&*])).*$",
                 message = "비밀번호는 영문, 숫자, 특수문자 중 2가지 이상을 조합하여 6~20자로 설정해야 합니다.")
-        @Schema(description = "비밀번호(영문/숫자/특수문자 포함 8~20자)", example = "Passw0rd!")
+        @Schema(description = "비밀번호(영문/숫자/특수문자 포함 6~20자)", example = "Passw0rd!")
         @NotBlank String password,
 
         @Email(message = "올바른 이메일 형식이어야 합니다.")

--- a/src/main/java/doritos/doriroom/notification/domain/Notification.java
+++ b/src/main/java/doritos/doriroom/notification/domain/Notification.java
@@ -25,7 +25,7 @@ public class Notification {
     private String content; // 알림 내용
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, length = 30)
     private NotificationType type; // 알림 타입
 
     @Column(length = 36)

--- a/src/main/java/doritos/doriroom/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/doritos/doriroom/notification/dto/NotificationResponseDto.java
@@ -2,8 +2,10 @@ package doritos.doriroom.notification.dto;
 
 import doritos.doriroom.notification.domain.Notification;
 import doritos.doriroom.notification.domain.NotificationType;
+import doritos.doriroom.user.domain.User;
 import lombok.Builder;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Builder
 public record NotificationResponseDto(
@@ -11,6 +13,7 @@ public record NotificationResponseDto(
         String content,
         NotificationType type,
         boolean isRead,
+        String targetId,
         LocalDateTime createdAt
 ) {
     public static NotificationResponseDto from(Notification notification) {
@@ -19,6 +22,7 @@ public record NotificationResponseDto(
                 .content(notification.getContent())
                 .type(notification.getType())
                 .isRead(notification.isRead())
+                .targetId(notification.getTargetId())
                 .createdAt(notification.getCreatedAt())
                 .build();
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

#173 

## 📝작업 내용

비밀번호 필드의 정규표현식을 화면상의 범위와 통일되도록 수정했습니다.
알림 조회 api의 응답 필드에 targetId를 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능/개선
  * 알림 응답에 targetId 필드를 추가하여 알림 대상 리소스를 식별·이동하기가 쉬워졌습니다.
  * 비밀번호 규칙을 최소 6자(기존 8자)로 완화했습니다. 대문자/소문자/숫자/특수문자 조합 규칙은 동일합니다.

* 작업
  * 알림 타입 컬럼에 길이 제약(최대 30자)을 적용해 데이터 일관성과 안정성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->