### PR TITLE
feat(auth): 회원가입 시 액세스 리프레시 토큰 반환 추가

### DIFF
--- a/src/main/java/doritos/doriroom/auth/controller/AuthController.java
+++ b/src/main/java/doritos/doriroom/auth/controller/AuthController.java
@@ -41,9 +41,8 @@ public class AuthController {
 
     @PostMapping("/signup")
     @Operation(summary = "회원가입")
-    public ApiResponse<Void> signup(@RequestBody @Valid SignupRequestDto request){
-        authService.signup(request);
-        return ApiResponse.ok();
+    public ApiResponse<LoginResponseDto> signup(@RequestBody @Valid SignupRequestDto request){
+        return ApiResponse.ok(authService.signup(request));
     }
 
     @PostMapping("/login")

--- a/src/main/java/doritos/doriroom/auth/service/AuthService.java
+++ b/src/main/java/doritos/doriroom/auth/service/AuthService.java
@@ -98,7 +98,7 @@ public class AuthService {
         redisTemplate.opsForValue().set(verifiedKey, "verified", Duration.ofSeconds(VERIFIED_EXPIRE_SECONDS));
     }
 
-    public void signup(SignupRequestDto request) {
+    public LoginResponseDto signup(SignupRequestDto request) {
         // 이메일 인증 완료 여부 확인
         String verifiedKey = VERIFIED_KEY_PREFIX.getValue() + request.email();
         String verified = (String) redisTemplate.opsForValue().get(verifiedKey);
@@ -141,6 +141,11 @@ public class AuthService {
         userItemRepository.saveAll(newUserItems);
 
         redisTemplate.delete(verifiedKey); // 유저 등록 후 인증 상태 삭제
+
+        String accessToken = jwtUtil.generateAccessToken(user);
+        String refreshToken = jwtUtil.generateRefresh(user);
+
+        return new LoginResponseDto(accessToken, refreshToken);
     }
 
     public LoginResponseDto login(LoginRequestDto request) {


### PR DESCRIPTION
## #️⃣연관된 이슈

#176 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 회원가입 응답에 로그인 정보(액세스/리프레시 토큰)가 포함되어 즉시 인증 상태를 획득할 수 있습니다.
  - 회원가입 직후 별도의 로그인 절차 없이 보호된 기능에 바로 접근할 수 있어 사용 흐름이 간소화되었습니다.
  - 클라이언트는 응답의 토큰을 사용해 세션 초기화 및 인증 상태 유지를 처리할 수 있습니다.
  - 응답 형식이 기존의 빈 응답에서 로그인 데이터 포함 형태로 변경되어, 클라이언트 핸들링 업데이트가 필요할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->