### PR TITLE
Feature/179 fcm

### DIFF
--- a/src/main/java/doritos/doriroom/notification/controller/NotificationController.java
+++ b/src/main/java/doritos/doriroom/notification/controller/NotificationController.java
@@ -2,7 +2,6 @@ package doritos.doriroom.notification.controller;
 
 import doritos.doriroom.global.dto.ApiResponse;
 import doritos.doriroom.notification.domain.NotificationType;
-import doritos.doriroom.notification.dto.NotificationRedirectDto;
 import doritos.doriroom.notification.dto.NotificationResponseDto;
 import doritos.doriroom.notification.service.NotificationService;
 import doritos.doriroom.user.domain.User;
@@ -27,12 +26,13 @@ public class NotificationController {
         return ApiResponse.ok(notificationService.getMyNotifications(user, pageable));
     }
 
-    @Operation(summary = "특정 알림 읽음 처리 및 알림 관련 페이지로 이동")
+    @Operation(summary = "특정 알림 읽음 처리")
     @PostMapping("/{notificationId}/read")
-    public ApiResponse<NotificationRedirectDto> readAndRedirect(@AuthenticationPrincipal User user,
+    public ApiResponse<Void> readNotification(@AuthenticationPrincipal User user,
                                                                 @Parameter(description = "처리할 알림의 ID")
                                                                 @PathVariable Long notificationId) {
-        return ApiResponse.ok(notificationService.readAndRedirect(user, notificationId));
+        notificationService.readNotification(user, notificationId);
+        return ApiResponse.ok();
     }
 
     @Operation(summary = "알림 발송 테스트")

--- a/src/main/java/doritos/doriroom/notification/dto/NotificationRedirectDto.java
+++ b/src/main/java/doritos/doriroom/notification/dto/NotificationRedirectDto.java
@@ -1,9 +1,0 @@
-package doritos.doriroom.notification.dto;
-
-public record NotificationRedirectDto(
-        String redirectUrl
-) {
-    public static NotificationRedirectDto of(String redirectUrl) {
-        return new NotificationRedirectDto(redirectUrl);
-    }
-}

--- a/src/main/java/doritos/doriroom/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/doritos/doriroom/notification/dto/NotificationResponseDto.java
@@ -2,10 +2,8 @@ package doritos.doriroom.notification.dto;
 
 import doritos.doriroom.notification.domain.Notification;
 import doritos.doriroom.notification.domain.NotificationType;
-import doritos.doriroom.user.domain.User;
 import lombok.Builder;
 import java.time.LocalDateTime;
-import java.util.UUID;
 
 @Builder
 public record NotificationResponseDto(

--- a/src/main/java/doritos/doriroom/notification/service/NotificationService.java
+++ b/src/main/java/doritos/doriroom/notification/service/NotificationService.java
@@ -5,7 +5,6 @@ import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import doritos.doriroom.notification.domain.Notification;
 import doritos.doriroom.notification.domain.NotificationType;
-import doritos.doriroom.notification.dto.NotificationRedirectDto;
 import doritos.doriroom.notification.dto.NotificationResponseDto;
 import doritos.doriroom.notification.exception.AccessDeniedException;
 import doritos.doriroom.notification.exception.NotificationNotFoundException;
@@ -21,7 +20,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 @Service
@@ -54,6 +52,7 @@ public class NotificationService {
                             .build();
 
             Map<String, String> data = new HashMap<>();
+            data.put("notificationId", notification.getId().toString());
             data.put("type", type.name());
             data.put("targetId", targetId);
             data.put("content", content);
@@ -90,7 +89,7 @@ public class NotificationService {
 
     // 알림 읽음 처리
     @Transactional
-    public NotificationRedirectDto readAndRedirect(User user, Long notificationId) {
+    public void readNotification(User user, Long notificationId) {
         Notification notification = notificationRepository.findById(notificationId)
                 .orElseThrow(NotificationNotFoundException::new);
 
@@ -101,20 +100,5 @@ public class NotificationService {
         if (!notification.isRead()) {
             notification.markAsRead(); // 안 읽은 상태인 경우 -> 읽음 상태로 변경
         }
-
-        String targetId = notification.getTargetId();
-        if (targetId == null || targetId.isBlank()) {
-            return NotificationRedirectDto.of("/");
-        }
-
-        String redirectUrl = switch (notification.getType()) {
-            case DIARY_LIKE        -> "/api/diary/" + targetId; // diaryId
-            case FOLLOWER      -> "/api/users/room/" + targetId; // userId
-            case CHALLENGE_REWARD  -> "/api/challenges/" + targetId; // challengeId
-            case GUESTBOOK_ENTRY -> "/api/guestbooks/room/" + targetId;  // roomOwnerId
-            default -> "/";
-        };
-
-        return NotificationRedirectDto.of(redirectUrl);
     }
 }

--- a/src/main/java/doritos/doriroom/notification/service/NotificationService.java
+++ b/src/main/java/doritos/doriroom/notification/service/NotificationService.java
@@ -20,7 +20,9 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -51,11 +53,17 @@ public class NotificationService {
                             .setBody(content)     // 푸시 알림 내용
                             .build();
 
+            Map<String, String> data = new HashMap<>();
+            data.put("type", type.name());
+            data.put("targetId", targetId);
+            data.put("content", content);
+
             TransactionSynchronizationManager.registerSynchronization(new  TransactionSynchronization() {
                 @Override
                 public void afterCommit() {
                     Message message = Message.builder()
                             .setNotification(fcmNotification)
+                            .putAllData(data)
                             .setToken(user.getFcmToken())
                             .build();
 


### PR DESCRIPTION
기존 알림 읽음 및 리다이렉트 url 반환 api를 단일 알림 읽음 api 로 변경했습니다.

푸시 알림 발송 시 알림 객체 payload에 notificationId를 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 알림 읽기 시 자동 이동 없이 읽음 처리만 수행됩니다.
  - 푸시 알림 데이터에 notificationId가 포함됩니다.
- 잡무
  - 사용되지 않는 DTO와 불필요한 import를 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->