### PR TITLE
feat(item): 유저 보유 아이템 응답 dto에 기본 아이템 여부 추가

### DIFF
--- a/src/main/java/doritos/doriroom/diary/service/DiaryLikeService.java
+++ b/src/main/java/doritos/doriroom/diary/service/DiaryLikeService.java
@@ -47,8 +47,16 @@ public class DiaryLikeService {
                     diary.incrementLikes();
                     diaryRepository.save(diary);
 
-                    // 일기 주인에게 좋아요 알림 발송
-                    notificationService.sendNotification(diaryOwner, NotificationType.DIARY_LIKE, user.getNickname(), diary.getDiaryId().toString());
+                    try {
+                        notificationService.sendNotification(
+                                diaryOwner,
+                                NotificationType.DIARY_LIKE,
+                                user.getNickname(),
+                                diary.getDiaryId().toString()
+                        );
+                    } catch (Exception notifyEx) {
+                        log.warn("알림 전송 실패: {}", notifyEx.getMessage());
+                    }
 
                     return true;
                 }

--- a/src/main/java/doritos/doriroom/item/dto/response/UserItemResponse.java
+++ b/src/main/java/doritos/doriroom/item/dto/response/UserItemResponse.java
@@ -10,24 +10,24 @@ import lombok.Builder;
 public record UserItemResponse (
         Long itemId,
         String name,
-//        String imageUrl,
         ItemType itemType,
         ItemGroup itemGroup, // COMMON or AREA
         AreaGroup areaGroup, // nullable
         CollectionTheme theme, // nullable
-        boolean isEquipped
+        boolean isEquipped,
+        boolean defaultItem
 ){
     public static UserItemResponse from(UserItem userItem){
         Item i = userItem.getItem();
         return UserItemResponse.builder()
                 .itemId(i.getItemId())
                 .name(i.getName())
-//                .imageUrl(i.getImageUrl())
                 .itemType(i.getItemType())
                 .itemGroup(i.getItemGroup())
                 .areaGroup(i.getAreaGroup())
                 .theme(i.getTheme())
                 .isEquipped(userItem.isEquipped())
+                .defaultItem(userItem.getItem().isDefaultItem())
                 .build();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#182 

## 📝작업 내용

응답 dto에 defaultItem 필드를 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 아이템에 "기본 아이템 여부" 표시가 추가되어 목록 및 상세에서 기본 아이템을 식별할 수 있습니다.
- 변경 사항
  - 일부 위치에서 더 이상 아이템 이미지 URL이 제공되지 않아 이미지가 표시되지 않을 수 있습니다.
- 버그 수정
  - 좋아요 처리 중 알림 전송 실패가 애플리케이션 동작을 중단시키지 않도록 예외를 안전하게 처리합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->